### PR TITLE
Improve input validation and clarify async API naming

### DIFF
--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -37,10 +37,15 @@ results = await async_parallel_map(
 | `batch_size` | `int \| None` | `None` | Process items in chunks (controls memory) |
 | `retry` | `Retry \| None` | `None` | Per-item retry with backoff |
 
-### Key Difference from Sync
+### Why `concurrency` instead of `workers`?
 
-- Uses `concurrency` (not `workers`) — controls task concurrency, not pool size
-- `task_timeout` is **per-task** (via `asyncio.wait_for`), not total
+The sync API uses `workers` because it sizes a thread/process **pool** — you're creating real OS threads or processes. The async API uses `concurrency` because there's no pool — everything runs on one event loop, and `concurrency` controls how many tasks are allowed to run at the same time via a semaphore.
+
+Calling both `workers` would be misleading (async has no workers). Calling both `concurrency` would be wrong for sync (you're literally setting `ThreadPoolExecutor(max_workers=N)`). The names match what each actually controls.
+
+### Other Differences from Sync
+
+- `task_timeout` is **per-task** (via `asyncio.wait_for`), not total wall-clock like sync `timeout`
 - Uses `asyncio.TaskGroup` for structured concurrency — proper cleanup on errors
 
 ### Examples

--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -15,7 +15,7 @@ results = await async_parallel_map(
     *,
     concurrency=4,                   # Max concurrent tasks
     rate_limit=None,                 # RateLimit or ops/second
-    timeout=None,                    # Per-task timeout in seconds
+    task_timeout=None,                    # Per-task timeout in seconds
     on_progress=None,                # callback(completed, total)
     batch_size=None,                 # Process in chunks to control memory
     retry=None,                      # Retry(attempts=3, backoff=1.0)
@@ -32,7 +32,7 @@ results = await async_parallel_map(
 | `items` | `Iterable` | required | Any iterable |
 | `concurrency` | `int` | `4` | Maximum concurrent tasks |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting |
-| `timeout` | `float \| None` | `None` | **Per-task** timeout in seconds |
+| `task_timeout` | `float \| None` | `None` | **Per-task** timeout in seconds |
 | `on_progress` | `Callable[[int, int], None] \| None` | `None` | Progress callback |
 | `batch_size` | `int \| None` | `None` | Process items in chunks (controls memory) |
 | `retry` | `Retry \| None` | `None` | Per-item retry with backoff |
@@ -40,7 +40,7 @@ results = await async_parallel_map(
 ### Key Difference from Sync
 
 - Uses `concurrency` (not `workers`) — controls task concurrency, not pool size
-- `timeout` is **per-task** (via `asyncio.wait_for`), not total
+- `task_timeout` is **per-task** (via `asyncio.wait_for`), not total
 - Uses `asyncio.TaskGroup` for structured concurrency — proper cleanup on errors
 
 ### Examples
@@ -60,7 +60,7 @@ results = await async_parallel_map(
     fetch, urls,
     concurrency=10,
     rate_limit=RateLimit(100, "minute"),
-    timeout=5.0,
+    task_timeout=5.0,
 )
 ```
 
@@ -97,7 +97,7 @@ data = await fetch("http://example.com")
 
 # Parallel
 results = await fetch.map(urls)
-results = await fetch.map(urls, concurrency=20, timeout=5.0)
+results = await fetch.map(urls, concurrency=20, task_timeout=5.0)
 ```
 
 ### Method Support

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -128,12 +128,19 @@ Built-in per-item retry with exponential backoff and jitter:
 from pyarallel import parallel_map, Retry
 
 # Retry up to 3 times with 1s base exponential backoff
+# Jitter is ON by default — randomizes delay ±50% to prevent thundering herd
 results = parallel_map(fetch, urls, workers=10, retry=Retry(attempts=3, backoff=1.0))
 
 # Only retry transient network errors — fail immediately on bad input
 results = parallel_map(fetch, urls, workers=10,
                        retry=Retry(on=(ConnectionError, TimeoutError)))
+
+# Cap max delay and disable jitter (useful for testing)
+results = parallel_map(fetch, urls, workers=10,
+                       retry=Retry(attempts=5, backoff=2.0, max_delay=30.0, jitter=False))
 ```
+
+**How backoff works:** delay = `backoff * 2^attempt`, capped at `max_delay`. With `jitter=True` (default), the delay is multiplied by a random factor between 0.5 and 1.5 — this prevents all workers from retrying at the exact same moment when a service recovers.
 
 Retries happen *inside the worker* — only the failing item is retried, not the entire batch. This composes cleanly with rate limiting and batching.
 

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -45,7 +45,7 @@ The async API supports per-task timeouts via `asyncio.wait_for`:
 ```python
 from pyarallel import async_parallel_map
 
-results = await async_parallel_map(fetch, urls, concurrency=10, timeout=5.0)
+results = await async_parallel_map(fetch, urls, concurrency=10, task_timeout=5.0)
 # Each individual task gets 5 seconds before timing out
 ```
 
@@ -117,7 +117,7 @@ async def fetch(url):
 
 data = await fetch("http://example.com")       # single call
 results = await fetch.map(urls)                 # parallel
-results = await fetch.map(urls, timeout=5.0)    # with per-task timeout
+results = await fetch.map(urls, task_timeout=5.0)  # with per-task timeout
 ```
 
 ## Retry

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -51,14 +51,14 @@ class _AsyncTokenBucket:
 
 async def _async_run_with_retry(
     fn: Callable[..., Any], item: Any, retry: Retry,
-    timeout: float | None = None,
+    task_timeout: float | None = None,
 ) -> Any:
     """Call async *fn(item)*, retrying on failure with exponential backoff."""
     last_exc: Exception | None = None
     for attempt in range(retry.attempts):
         try:
-            if timeout is not None:
-                return await asyncio.wait_for(fn(item), timeout=timeout)
+            if task_timeout is not None:
+                return await asyncio.wait_for(fn(item), timeout=task_timeout)
             return await fn(item)
         except Exception as exc:
             last_exc = exc
@@ -77,7 +77,7 @@ async def async_parallel_map(
     *,
     concurrency: int = 4,
     rate_limit: RateLimit | float | None = None,
-    timeout: float | None = None,
+    task_timeout: float | None = None,
     on_progress: Callable[[int, int], None] | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
@@ -89,7 +89,7 @@ async def async_parallel_map(
         items: Any iterable.
         concurrency: Maximum number of tasks running at once.
         rate_limit: ``RateLimit`` object, or ops-per-second as a number.
-        timeout: Per-task timeout in seconds.
+        task_timeout: Per-task timeout in seconds (each individual task).
         on_progress: ``callback(completed, total)`` after each task.
         batch_size: Process items in chunks to control memory.
         retry: ``Retry`` object for per-item retry with backoff.
@@ -121,9 +121,9 @@ async def async_parallel_map(
                 await limiter.wait()
             try:
                 if retry is not None:
-                    result = await _async_run_with_retry(fn, item, retry, timeout=timeout)
-                elif timeout is not None:
-                    result = await asyncio.wait_for(fn(item), timeout=timeout)
+                    result = await _async_run_with_retry(fn, item, retry, task_timeout=task_timeout)
+                elif task_timeout is not None:
+                    result = await asyncio.wait_for(fn(item), timeout=task_timeout)
                 else:
                     result = await fn(item)
                 results[i] = result
@@ -164,14 +164,14 @@ class _BoundAsyncParallel:
         *,
         concurrency: int | None = None,
         rate_limit: RateLimit | float | None = None,
-        timeout: float | None = None,
+        task_timeout: float | None = None,
         on_progress: Callable[[int, int], None] | None = None,
         batch_size: int | None = None,
         retry: Retry | None = None,
     ) -> ParallelResult[Any]:
         return await async_parallel_map(self._fn, items, **_merge_opts(
             self._defaults, concurrency=concurrency, rate_limit=rate_limit,
-            timeout=timeout, on_progress=on_progress, batch_size=batch_size,
+            task_timeout=task_timeout, on_progress=on_progress, batch_size=batch_size,
             retry=retry,
         ))
 
@@ -207,14 +207,14 @@ class _AsyncParallelFunc:
         *,
         concurrency: int | None = None,
         rate_limit: RateLimit | float | None = None,
-        timeout: float | None = None,
+        task_timeout: float | None = None,
         on_progress: Callable[[int, int], None] | None = None,
         batch_size: int | None = None,
         retry: Retry | None = None,
     ) -> ParallelResult[Any]:
         return await async_parallel_map(self.__wrapped__, items, **_merge_opts(
             self._defaults, concurrency=concurrency, rate_limit=rate_limit,
-            timeout=timeout, on_progress=on_progress, batch_size=batch_size,
+            task_timeout=task_timeout, on_progress=on_progress, batch_size=batch_size,
             retry=retry,
         ))
 

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -47,13 +47,19 @@ class RateLimit:
     count: float
     per: Literal["second", "minute", "hour"] = "second"
 
+    _VALID_INTERVALS = {"second": 1, "minute": 60, "hour": 3600}
+
     def __post_init__(self) -> None:
         if self.count <= 0:
             raise ValueError(f"RateLimit count must be positive, got {self.count}")
+        if self.per not in self._VALID_INTERVALS:
+            raise ValueError(
+                f'RateLimit per must be "second", "minute", or "hour", got {self.per!r}'
+            )
 
     @property
     def per_second(self) -> float:
-        return self.count / {"second": 1, "minute": 60, "hour": 3600}[self.per]
+        return self.count / self._VALID_INTERVALS[self.per]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -102,7 +102,7 @@ class TestAsyncTimeout:
             return x
 
         result = await async_parallel_map(
-            slow, [1, 2], concurrency=2, timeout=0.1
+            slow, [1, 2], concurrency=2, task_timeout=0.1
         )
         assert not result.ok
         assert len(result.failures()) == 2

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -144,3 +144,14 @@ class TestValidation:
         from pyarallel import parallel_map
         with pytest.raises(ValueError, match=">= 1"):
             parallel_map(lambda x: x, [1], workers=0)
+
+    def test_rate_limit_invalid_per_raises(self):
+        from pyarallel import RateLimit
+        with pytest.raises(ValueError, match='"second", "minute", or "hour"'):
+            RateLimit(10, "minuet")
+
+    def test_rate_limit_valid_per_accepted(self):
+        from pyarallel import RateLimit
+        for per in ("second", "minute", "hour"):
+            r = RateLimit(10, per)
+            assert r.per_second > 0


### PR DESCRIPTION
## Summary

- **Validate `RateLimit.per` at runtime** — `RateLimit(10, "minuet")` now raises `ValueError` instead of a cryptic `KeyError` deep in `per_second`. The `Literal` type hint gives IDE autocomplete, `__post_init__` catches typos at construction.
- **Rename async `timeout` → `task_timeout`** — same param name with different semantics (total wall-clock vs per-task) was a footgun. Now the names are self-documenting: sync uses `timeout`, async uses `task_timeout`.
- **Add docs note explaining `workers` vs `concurrency`** — different names because different mechanisms (thread/process pool vs asyncio semaphore). Called out explicitly so no one has to wonder.
- **Show all Retry params in docs** — jitter, max_delay, and backoff formula were mentioned but never shown in examples.

## Test plan

- [x] 111 tests passing
- [x] `RateLimit(10, "typo")` → clear `ValueError`
- [x] `RateLimit(10, "minute")` / `"second"` / `"hour"` all work
- [x] Async tests updated to use `task_timeout=`
- [x] Docs examples match actual API signatures

https://claude.ai/code/session_01RHTs4at74CA2wwTTQWQo52
