### PR TITLE
Smart worker defaults, task_timeout guard, workers alias in async

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -21,14 +21,11 @@
 - **Result streaming** — yield results as they complete (iterator API)
 - **tqdm/rich integration** — built-in progress bar support
 
-### Medium Term
-
-- **Per-task timeout (sync)** — individual task deadlines for thread/process pools
-
 ### Exploring
 
 - **Free-threading support** — leverage Python 3.13+ no-GIL for true thread parallelism
 - **Resource-aware scheduling** — adaptive worker counts based on system load
+- **Per-task timeout (sync)** — Python threads cannot be cancelled mid-execution, so per-task timeout in sync is a hard problem with no clean solution. The async API supports `task_timeout` natively via `asyncio.wait_for`. For sync, use `timeout=` for total wall-clock limits and put timeouts inside your function (e.g., `requests.get(url, timeout=5)`).
 
 ---
 

--- a/docs/user-guide/best-practices.md
+++ b/docs/user-guide/best-practices.md
@@ -30,21 +30,24 @@ results = parallel_map(compute, data, workers=4, executor="process")
 !!! warning
     Process executor requires picklable functions. Use module-level named functions, not lambdas or closures.
 
-### Worker Count Guidelines
+### Worker Count
 
-- **CPU-bound**: `multiprocessing.cpu_count()` or fewer
-- **I/O-bound**: 10-50x the number of cores, depending on latency
+By default, `workers=None` — the stdlib picks a sensible number automatically:
+
+- **Threads**: `min(32, cpu_count + 4)` — Python's `ThreadPoolExecutor` default
+- **Processes**: `cpu_count()` — Python's `ProcessPoolExecutor` default
+
+Most of the time you don't need to set `workers` at all. Override only when you have a reason:
 
 ```python
-import multiprocessing
+# Just use the defaults — they're good
+results = parallel_map(fetch, urls)
+results = parallel_map(crunch, data, executor="process")
 
-# CPU-bound
-results = parallel_map(crunch, data,
-                       workers=multiprocessing.cpu_count(),
-                       executor="process")
-
-# I/O-bound
-results = parallel_map(fetch, urls, workers=32)
+# Override when you know better
+results = parallel_map(fetch, urls, workers=100)       # high concurrency for fast APIs
+results = parallel_map(crunch, data, executor="process",
+                       workers=multiprocessing.cpu_count() - 1)  # leave a core free
 ```
 
 ## Rate Limiting

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -81,6 +81,7 @@ async def async_parallel_map(
     on_progress: Callable[[int, int], None] | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
+    workers: int | None = None,
 ) -> ParallelResult[R]:
     """Execute an async *fn* over *items* concurrently.
 
@@ -93,10 +94,20 @@ async def async_parallel_map(
         on_progress: ``callback(completed, total)`` after each task.
         batch_size: Process items in chunks to control memory.
         retry: ``Retry`` object for per-item retry with backoff.
+        workers: Alias for ``concurrency`` (for convenience when switching
+            from sync API). Emits a warning; prefer ``concurrency``.
 
     Returns:
         ``ParallelResult`` — same container as the sync API.
     """
+    if workers is not None:
+        import warnings
+        warnings.warn(
+            "workers= is not used in async_parallel_map — "
+            "did you mean concurrency=? Setting concurrency to the workers value.",
+            stacklevel=2,
+        )
+        concurrency = workers
     if isinstance(rate_limit, (int, float)):
         rate_limit = RateLimit(rate_limit)
     if batch_size is not None and batch_size < 1:

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -269,6 +269,7 @@ def parallel_map(
     on_progress: Callable[[int, int], None] | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
+    task_timeout: float | None = None,
 ) -> ParallelResult[R]:
     """Execute *fn* over *items* in parallel, returning ordered results.
 
@@ -297,6 +298,13 @@ def parallel_map(
         raise ValueError(f"workers must be >= 1, got {workers}")
     if executor not in ("thread", "process"):
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
+    if task_timeout is not None:
+        raise NotImplementedError(
+            "task_timeout is not supported in sync parallel_map — Python threads "
+            "cannot be cancelled mid-execution. Use timeout= for a total wall-clock "
+            "limit, or put timeouts inside your function (e.g. requests.get(url, timeout=5)). "
+            "For per-task timeouts, use async_parallel_map with task_timeout=."
+        )
 
     items_list = list(items)
     n = len(items_list)

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -262,7 +262,7 @@ def parallel_map(
     fn: Callable[..., R],
     items: Iterable[Any],
     *,
-    workers: int = 4,
+    workers: int | None = None,
     executor: ExecutorType = "thread",
     rate_limit: RateLimit | float | None = None,
     timeout: float | None = None,
@@ -275,7 +275,9 @@ def parallel_map(
     Args:
         fn: Function applied to each item.
         items: Any iterable (list, generator, range, …).
-        workers: Number of parallel workers.
+        workers: Number of parallel workers. Defaults to ``None`` which lets
+            the executor decide — ``min(32, cpu_count+4)`` for threads,
+            ``cpu_count()`` for processes.
         executor: ``"thread"`` for I/O-bound, ``"process"`` for CPU-bound.
         rate_limit: ``RateLimit`` object, or a plain number (ops per second).
         timeout: Total wall-clock timeout in seconds for the whole operation.
@@ -291,7 +293,7 @@ def parallel_map(
         rate_limit = RateLimit(rate_limit)
     if batch_size is not None and batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
-    if workers < 1:
+    if workers is not None and workers < 1:
         raise ValueError(f"workers must be >= 1, got {workers}")
     if executor not in ("thread", "process"):
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
@@ -406,12 +408,14 @@ class _ParallelFunc:
         self,
         fn: Callable[..., Any],
         *,
-        workers: int,
+        workers: int | None,
         executor: ExecutorType,
         rate_limit: RateLimit | float | None,
     ) -> None:
         self.__wrapped__ = fn
-        self._defaults: dict[str, Any] = {"workers": workers, "executor": executor}
+        self._defaults: dict[str, Any] = {"executor": executor}
+        if workers is not None:
+            self._defaults["workers"] = workers
         if rate_limit is not None:
             self._defaults["rate_limit"] = rate_limit
         functools.update_wrapper(self, fn)
@@ -448,7 +452,7 @@ class _ParallelFunc:
 def parallel(
     fn: Callable[..., R] | None = None,
     *,
-    workers: int = 4,
+    workers: int | None = None,
     executor: ExecutorType = "thread",
     rate_limit: RateLimit | float | None = None,
 ) -> Any:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -191,3 +191,17 @@ class TestAsyncDecorator:
         assert await f.fetch("a") == "data-a"
         results = await f.fetch.map(["a", "b", "c"])
         assert list(results) == ["data-a", "data-b", "data-c"]
+
+
+class TestAsyncWorkersAlias:
+    async def test_workers_warns_and_works(self):
+        async def double(x):
+            return x * 2
+
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = await async_parallel_map(double, [1, 2, 3], workers=2)
+            assert len(w) == 1
+            assert "did you mean concurrency" in str(w[0].message)
+        assert list(result) == [2, 4, 6]

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -145,6 +145,11 @@ class TestValidation:
         with pytest.raises(ValueError, match=">= 1"):
             parallel_map(lambda x: x, [1], workers=0)
 
+    def test_task_timeout_in_sync_raises(self):
+        from pyarallel import parallel_map
+        with pytest.raises(NotImplementedError, match="task_timeout is not supported"):
+            parallel_map(lambda x: x, [1], task_timeout=5.0)
+
     def test_rate_limit_invalid_per_raises(self):
         from pyarallel import RateLimit
         with pytest.raises(ValueError, match='"second", "minute", or "hour"'):


### PR DESCRIPTION
## Summary

- **Smart worker defaults** — `workers=None` (default) lets stdlib pick: `min(32, cpu_count+4)` for threads, `cpu_count()` for processes. No more arbitrary hardcoded 4.
- **`task_timeout` guard in sync** — passing `task_timeout=` to `parallel_map` raises `NotImplementedError` with a clear message explaining why it's not possible and what to do instead.
- **`workers=` alias in async** — passing `workers=` to `async_parallel_map` emits a warning ("did you mean concurrency=?") and maps the value, instead of crashing with TypeError.
- **Roadmap update** — moved per-task timeout (sync) to "Exploring" with honest explanation.

## Test plan

- [x] 113 tests passing
- [x] `parallel_map(fn, items)` with no `workers` kwarg works (stdlib default)
- [x] `parallel_map(fn, items, executor="process")` uses `cpu_count()` by default
- [x] `parallel_map(fn, items, task_timeout=5)` → clear `NotImplementedError`
- [x] `async_parallel_map(fn, items, workers=10)` → warning + works with `concurrency=10`

https://claude.ai/code/session_01RHTs4at74CA2wwTTQWQo52
