### PR TITLE
Add starmap and streaming (parallel_iter / .stream())

### DIFF
--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -71,6 +71,46 @@ results = await async_parallel_map(
 
 ---
 
+## `async_parallel_starmap`
+
+Like `async_parallel_map` but unpacks each item as `fn(*args)`.
+
+```python
+from pyarallel import async_parallel_starmap
+
+async def add(a, b): return a + b
+
+results = await async_parallel_starmap(add, [(1, 2), (3, 4)], concurrency=4)
+# ParallelResult([3, 7])
+```
+
+Takes the same options as `async_parallel_map`. Also available as `.starmap()` on `@async_parallel` decorated functions.
+
+---
+
+## `async_parallel_iter`
+
+Async streaming — yields `(index, result_or_exception)` in completion order. Constant memory.
+
+```python
+from pyarallel import async_parallel_iter
+
+async for index, value in async_parallel_iter(fetch, urls, concurrency=10):
+    await db.save(value)
+```
+
+Also available as `.stream()` on `@async_parallel` decorated functions:
+
+```python
+@async_parallel(concurrency=10)
+async def fetch(url): ...
+
+async for index, value in fetch.stream(urls, batch_size=1000):
+    await db.save(value)
+```
+
+---
+
 ## `@async_parallel`
 
 Decorator that adds `.map()` for async parallel execution.

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -124,6 +124,91 @@ Service.compute.map([1, 2, 3])  # static method
 
 ---
 
+## `parallel_starmap`
+
+Like `parallel_map` but unpacks each item as `fn(*args)` — for functions that take multiple arguments.
+
+```python
+from pyarallel import parallel_starmap
+
+results = parallel_starmap(fn, [(arg1, arg2), (arg3, arg4), ...], workers=4)
+```
+
+Takes the same options as `parallel_map` (workers, executor, rate_limit, timeout, batch_size, retry).
+
+### Examples
+
+```python
+def add(a, b):
+    return a + b
+
+results = parallel_starmap(add, [(1, 2), (3, 4), (5, 6)])  # [3, 7, 11]
+
+# With retry
+results = parallel_starmap(fetch_with_auth, [(url, token) for url in urls],
+                           workers=10, retry=Retry(attempts=3))
+```
+
+Also available as `.starmap()` on `@parallel` decorated functions:
+
+```python
+@parallel(workers=4)
+def add(a, b): return a + b
+
+add.starmap([(1, 2), (3, 4)])  # ParallelResult([3, 7])
+```
+
+---
+
+## `parallel_iter`
+
+Streaming version of `parallel_map` — yields `(index, result_or_exception)` in completion order. Results are **not accumulated in memory**.
+
+```python
+from pyarallel import parallel_iter
+
+for index, value in parallel_iter(fn, items, workers=4, batch_size=1000):
+    if isinstance(value, Exception):
+        log_error(index, value)
+    else:
+        db.save(value)
+```
+
+### When to Use
+
+- **`parallel_map`** — results fit in memory, you need `ParallelResult` features (.ok, .successes(), .failures())
+- **`parallel_iter`** — large-scale processing where results should be consumed and discarded (10M+ items, ETL pipelines, streaming to DB)
+
+### Parameters
+
+Same as `parallel_map` except no `timeout` or `on_progress` (results stream as they complete).
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `fn` | `Callable` | required | Function to apply to each item |
+| `items` | `Iterable` | required | Any iterable |
+| `workers` | `int` | `4` | Number of parallel workers |
+| `executor` | `"thread" \| "process"` | `"thread"` | Thread pool or process pool |
+| `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting |
+| `batch_size` | `int \| None` | `None` | Process in chunks (controls memory) |
+| `retry` | `Retry \| None` | `None` | Per-item retry |
+
+### Yields
+
+`(int, T | Exception)` — index and result in **completion order** (not input order). Failed tasks yield the exception as the value.
+
+Also available as `.stream()` on `@parallel` decorated functions:
+
+```python
+@parallel(workers=8)
+def process(item): ...
+
+for index, value in process.stream(huge_list, batch_size=1000):
+    db.save(value)
+```
+
+---
+
 ## `ParallelResult`
 
 Container for parallel execution results. Behaves like a `list` when all tasks succeed. Provides structured access when some fail.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -2,23 +2,23 @@
 
 ## Current (v0.2.0)
 
-- `parallel_map()` — explicit parallel execution over iterables
-- `@parallel` decorator with `.map()` — preserves function signature
-- `async_parallel_map()` and `@async_parallel` — full async support
+- `parallel_map()` / `.map()` — explicit parallel execution over iterables
+- `parallel_starmap()` / `.starmap()` — multi-argument parallel execution
+- `parallel_iter()` / `.stream()` — streaming results in completion order, constant memory
+- `@parallel` and `@async_parallel` decorators — preserves function signature
+- Full async support via `asyncio.TaskGroup`
 - `ParallelResult` with structured error handling (`ExceptionGroup`)
 - `RateLimit` — token bucket rate limiting (sync and async)
 - `Retry` — per-item retry with exponential backoff, jitter, and exception filtering
 - `batch_size` — process items in chunks to control memory
 - Progress callbacks via `on_progress`
-- Timeout support (total for sync, per-task for async)
+- Timeout support (`timeout` for sync total, `task_timeout` for async per-task)
 - Instance method support via descriptor protocol
 
 ## Planned
 
 ### Near Term
 
-- **`starmap` support** — map over multi-argument inputs
-- **Result streaming** — yield results as they complete (iterator API)
 - **tqdm/rich integration** — built-in progress bar support
 
 ### Exploring

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -19,6 +19,9 @@
 
 ### Near Term
 
+- **`max_errors`** — stop early after N failures instead of processing all items. When hitting a dead API, don't waste 10,000 calls when the first 10 all failed. Returns partial results.
+- **Ordered streaming** — `parallel_iter(..., ordered=True)` yields results in input order instead of completion order. Essential for ETL, CSV writing, and pipelines where output order must match input.
+- **`max_tasks_per_worker`** — restart process workers after N tasks to prevent memory leaks in long-running pools. Passes through to `ProcessPoolExecutor(max_tasks_per_child=)`.
 - **tqdm/rich integration** — built-in progress bar support
 
 ### Exploring

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -157,6 +157,59 @@ results = parallel_map(process, huge_list, workers=8, batch_size=500)
 
 Errors in one batch don't prevent subsequent batches from running.
 
+## Starmap — Multi-Argument Functions
+
+For functions that take multiple arguments, use `parallel_starmap` or `.starmap()`:
+
+```python
+from pyarallel import parallel_starmap
+
+def fetch_with_auth(url, token):
+    return requests.get(url, headers={"Authorization": token}).json()
+
+results = parallel_starmap(fetch_with_auth,
+                           [(url, token) for url in urls],
+                           workers=10)
+
+# Or with the decorator
+@parallel(workers=10)
+def fetch_with_auth(url, token): ...
+
+results = fetch_with_auth.starmap([(url1, token), (url2, token)])
+```
+
+## Streaming — Constant Memory
+
+For large-scale processing where results shouldn't accumulate in memory, use `parallel_iter` or `.stream()`:
+
+```python
+from pyarallel import parallel_iter
+
+# Process 10M items — only one batch of results in memory at a time
+for index, value in parallel_iter(process, ten_million_items,
+                                  workers=8, batch_size=1000):
+    if isinstance(value, Exception):
+        log_error(index, value)
+    else:
+        db.save(value)
+
+# Or with the decorator
+@parallel(workers=8)
+def process(item): ...
+
+for index, value in process.stream(huge_list, batch_size=1000):
+    db.save(value)
+```
+
+Results arrive in **completion order** (fastest tasks first), not input order. Each `(index, value)` tuple includes the original index so you can match results to inputs.
+
+**When to use which:**
+
+| API | Memory | Use case |
+|---|---|---|
+| `.map()` / `parallel_map` | All results in memory | Results fit in memory, need `.ok`, `.failures()` |
+| `.stream()` / `parallel_iter` | Constant (one batch) | ETL, streaming to DB, 10M+ items |
+
 ## Structured Error Handling
 
 `ParallelResult` never silently drops errors:

--- a/pyarallel/__init__.py
+++ b/pyarallel/__init__.py
@@ -1,7 +1,20 @@
 """Pyarallel — simple, explicit parallel execution for Python."""
 
-from .core import ParallelResult, RateLimit, Retry, parallel, parallel_map
-from .aio import async_parallel, async_parallel_map
+from .core import (
+    ParallelResult,
+    RateLimit,
+    Retry,
+    parallel,
+    parallel_iter,
+    parallel_map,
+    parallel_starmap,
+)
+from .aio import (
+    async_parallel,
+    async_parallel_iter,
+    async_parallel_map,
+    async_parallel_starmap,
+)
 
 __version__ = "0.2.0"
 __all__ = [
@@ -9,7 +22,11 @@ __all__ = [
     "RateLimit",
     "Retry",
     "parallel",
+    "parallel_iter",
     "parallel_map",
+    "parallel_starmap",
     "async_parallel",
+    "async_parallel_iter",
     "async_parallel_map",
+    "async_parallel_starmap",
 ]

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+from collections.abc import AsyncIterator
 from typing import Any, Callable, Iterable, TypeVar
 
 from .core import ParallelResult, RateLimit, Retry, _Failure, _make_chunks, _merge_opts, _PENDING
@@ -152,6 +153,91 @@ async def async_parallel_map(
     return ParallelResult(results)
 
 
+async def async_parallel_starmap(
+    fn: Callable[..., Any],
+    items: Iterable[tuple[Any, ...]],
+    *,
+    concurrency: int = 4,
+    rate_limit: RateLimit | float | None = None,
+    task_timeout: float | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
+    batch_size: int | None = None,
+    retry: Retry | None = None,
+) -> ParallelResult[R]:
+    """Like ``async_parallel_map`` but unpacks each item as ``fn(*args)``."""
+    async def _unpack(args: tuple[Any, ...]) -> Any:
+        return await fn(*args)
+
+    return await async_parallel_map(
+        _unpack, items,
+        concurrency=concurrency, rate_limit=rate_limit,
+        task_timeout=task_timeout, on_progress=on_progress,
+        batch_size=batch_size, retry=retry,
+    )
+
+
+async def async_parallel_iter(
+    fn: Callable[..., Any],
+    items: Iterable[Any],
+    *,
+    concurrency: int = 4,
+    rate_limit: RateLimit | float | None = None,
+    task_timeout: float | None = None,
+    batch_size: int | None = None,
+    retry: Retry | None = None,
+) -> AsyncIterator[tuple[int, Any]]:
+    """Execute async *fn* over *items*, yielding ``(index, result)``
+    in completion order. Constant memory — results are not accumulated.
+    """
+    if isinstance(rate_limit, (int, float)):
+        rate_limit = RateLimit(rate_limit)
+    if batch_size is not None and batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be >= 1, got {concurrency}")
+
+    items_list = list(items)
+    n = len(items_list)
+    if n == 0:
+        return
+
+    semaphore = asyncio.Semaphore(concurrency)
+    limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
+    queue: asyncio.Queue[tuple[int, Any] | None] = asyncio.Queue()
+
+    async def _run(i: int, item: Any) -> None:
+        async with semaphore:
+            if limiter:
+                await limiter.wait()
+            try:
+                if retry is not None:
+                    result = await _async_run_with_retry(fn, item, retry, task_timeout=task_timeout)
+                elif task_timeout is not None:
+                    result = await asyncio.wait_for(fn(item), timeout=task_timeout)
+                else:
+                    result = await fn(item)
+                await queue.put((i, result))
+            except Exception as exc:
+                await queue.put((i, exc))
+
+    tasks_remaining = 0
+    for chunk in _make_chunks(n, batch_size):
+        chunk_tasks = []
+        for i in chunk:
+            tasks_remaining += 1
+            chunk_tasks.append(asyncio.create_task(_run(i, items_list[i])))
+
+        yielded_in_chunk = 0
+        while yielded_in_chunk < len(chunk_tasks):
+            item = await queue.get()
+            if item is not None:
+                yield item
+                yielded_in_chunk += 1
+
+        for t in chunk_tasks:
+            await t
+
+
 # ---------------------------------------------------------------------------
 # @async_parallel decorator
 # ---------------------------------------------------------------------------
@@ -185,6 +271,13 @@ class _BoundAsyncParallel:
             task_timeout=task_timeout, on_progress=on_progress, batch_size=batch_size,
             retry=retry,
         ))
+
+    async def starmap(self, items: Iterable[tuple[Any, ...]], **kwargs: Any) -> ParallelResult[Any]:
+        return await async_parallel_starmap(self._fn, items, **_merge_opts(self._defaults, **kwargs))
+
+    async def stream(self, items: Iterable[Any], **kwargs: Any) -> AsyncIterator[tuple[int, Any]]:
+        async for item in async_parallel_iter(self._fn, items, **_merge_opts(self._defaults, **kwargs)):
+            yield item
 
 
 class _AsyncParallelFunc:
@@ -228,6 +321,13 @@ class _AsyncParallelFunc:
             task_timeout=task_timeout, on_progress=on_progress, batch_size=batch_size,
             retry=retry,
         ))
+
+    async def starmap(self, items: Iterable[tuple[Any, ...]], **kwargs: Any) -> ParallelResult[Any]:
+        return await async_parallel_starmap(self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs))
+
+    async def stream(self, items: Iterable[Any], **kwargs: Any) -> AsyncIterator[tuple[int, Any]]:
+        async for item in async_parallel_iter(self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs)):
+            yield item
 
 
 def async_parallel(

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -220,22 +220,33 @@ async def async_parallel_iter(
             except Exception as exc:
                 await queue.put((i, exc))
 
-    tasks_remaining = 0
-    for chunk in _make_chunks(n, batch_size):
-        chunk_tasks = []
-        for i in chunk:
-            tasks_remaining += 1
-            chunk_tasks.append(asyncio.create_task(_run(i, items_list[i])))
+    active_tasks: list[asyncio.Task[None]] = []
+    try:
+        for chunk in _make_chunks(n, batch_size):
+            chunk_tasks = []
+            for i in chunk:
+                t = asyncio.create_task(_run(i, items_list[i]))
+                chunk_tasks.append(t)
+                active_tasks.append(t)
 
-        yielded_in_chunk = 0
-        while yielded_in_chunk < len(chunk_tasks):
-            item = await queue.get()
-            if item is not None:
-                yield item
-                yielded_in_chunk += 1
+            yielded_in_chunk = 0
+            while yielded_in_chunk < len(chunk_tasks):
+                item = await queue.get()
+                if item is not None:
+                    yield item
+                    yielded_in_chunk += 1
 
-        for t in chunk_tasks:
-            await t
+            for t in chunk_tasks:
+                await t
+            active_tasks.clear()
+    finally:
+        for t in active_tasks:
+            t.cancel()
+        for t in active_tasks:
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -368,6 +368,98 @@ def parallel_map(
     return ParallelResult(results)
 
 
+def parallel_starmap(
+    fn: Callable[..., R],
+    items: Iterable[tuple[Any, ...]],
+    *,
+    workers: int = 4,
+    executor: ExecutorType = "thread",
+    rate_limit: RateLimit | float | None = None,
+    timeout: float | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
+    batch_size: int | None = None,
+    retry: Retry | None = None,
+) -> ParallelResult[R]:
+    """Like ``parallel_map`` but unpacks each item as ``fn(*args)``.
+
+    Example::
+
+        def add(a, b): return a + b
+        parallel_starmap(add, [(1, 2), (3, 4)])  # [3, 7]
+    """
+    return parallel_map(
+        lambda args: fn(*args), items,
+        workers=workers, executor=executor, rate_limit=rate_limit,
+        timeout=timeout, on_progress=on_progress, batch_size=batch_size,
+        retry=retry,
+    )
+
+
+def parallel_iter(
+    fn: Callable[..., R],
+    items: Iterable[Any],
+    *,
+    workers: int = 4,
+    executor: ExecutorType = "thread",
+    rate_limit: RateLimit | float | None = None,
+    batch_size: int | None = None,
+    retry: Retry | None = None,
+) -> Iterator[tuple[int, R | Exception]]:
+    """Execute *fn* over *items* in parallel, yielding ``(index, result)``
+    in completion order.
+
+    Unlike ``parallel_map``, results are not accumulated in memory — they
+    are yielded as they complete. For failed tasks, the value is the
+    exception instance.
+
+    Example::
+
+        for index, value in parallel_iter(process, huge_list, batch_size=1000):
+            if isinstance(value, Exception):
+                log_error(index, value)
+            else:
+                db.save(value)
+    """
+    if isinstance(rate_limit, (int, float)):
+        rate_limit = RateLimit(rate_limit)
+    if batch_size is not None and batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1, got {workers}")
+    if executor not in ("thread", "process"):
+        raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
+
+    items_list = list(items)
+    n = len(items_list)
+    if n == 0:
+        return
+
+    task_fn = fn
+    if retry is not None:
+        task_fn = functools.partial(_run_with_retry, fn, retry=retry)
+
+    pool_cls = ThreadPoolExecutor if executor == "thread" else ProcessPoolExecutor
+    bucket = _TokenBucket(rate_limit) if rate_limit else None
+
+    pool = pool_cls(max_workers=workers)
+    try:
+        for chunk in _make_chunks(n, batch_size):
+            futures: dict[Future[R], int] = {}
+            for i in chunk:
+                if bucket:
+                    bucket.wait()
+                futures[pool.submit(task_fn, items_list[i])] = i
+
+            for future in as_completed(futures):
+                idx = futures[future]
+                try:
+                    yield (idx, future.result())
+                except Exception as exc:
+                    yield (idx, exc)
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
 # ---------------------------------------------------------------------------
 # @parallel decorator
 # ---------------------------------------------------------------------------
@@ -403,6 +495,22 @@ class _BoundParallel:
             rate_limit=rate_limit, timeout=timeout, on_progress=on_progress,
             batch_size=batch_size, retry=retry,
         ))
+
+    def starmap(
+        self,
+        items: Iterable[tuple[Any, ...]],
+        **kwargs: Any,
+    ) -> ParallelResult[Any]:
+        """Like ``.map()`` but unpacks each item as ``fn(*args)``."""
+        return parallel_starmap(self._fn, items, **_merge_opts(self._defaults, **kwargs))
+
+    def stream(
+        self,
+        items: Iterable[Any],
+        **kwargs: Any,
+    ) -> Iterator[tuple[int, Any]]:
+        """Yield ``(index, result)`` in completion order — constant memory."""
+        return parallel_iter(self._fn, items, **_merge_opts(self._defaults, **kwargs))
 
 
 class _ParallelFunc:
@@ -455,6 +563,22 @@ class _ParallelFunc:
             rate_limit=rate_limit, timeout=timeout, on_progress=on_progress,
             batch_size=batch_size, retry=retry,
         ))
+
+    def starmap(
+        self,
+        items: Iterable[tuple[Any, ...]],
+        **kwargs: Any,
+    ) -> ParallelResult[Any]:
+        """Like ``.map()`` but unpacks each item as ``fn(*args)``."""
+        return parallel_starmap(self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs))
+
+    def stream(
+        self,
+        items: Iterable[Any],
+        **kwargs: Any,
+    ) -> Iterator[tuple[int, Any]]:
+        """Yield ``(index, result)`` in completion order — constant memory."""
+        return parallel_iter(self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs))
 
 
 def parallel(

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -368,6 +368,12 @@ def parallel_map(
     return ParallelResult(results)
 
 
+def _unpack_call(fn_and_args: tuple[Callable[..., Any], tuple[Any, ...]]) -> Any:
+    """Unpack and call fn(*args) — picklable for process executor."""
+    fn, args = fn_and_args
+    return fn(*args)
+
+
 def parallel_starmap(
     fn: Callable[..., R],
     items: Iterable[tuple[Any, ...]],
@@ -387,8 +393,9 @@ def parallel_starmap(
         def add(a, b): return a + b
         parallel_starmap(add, [(1, 2), (3, 4)])  # [3, 7]
     """
+    packed = [(fn, args) for args in items]
     return parallel_map(
-        lambda args: fn(*args), items,
+        _unpack_call, packed,
         workers=workers, executor=executor, rate_limit=rate_limit,
         timeout=timeout, on_progress=on_progress, batch_size=batch_size,
         retry=retry,
@@ -429,26 +436,33 @@ def parallel_iter(
     if executor not in ("thread", "process"):
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
 
-    items_list = list(items)
-    n = len(items_list)
-    if n == 0:
-        return
-
     task_fn = fn
     if retry is not None:
         task_fn = functools.partial(_run_with_retry, fn, retry=retry)
 
     pool_cls = ThreadPoolExecutor if executor == "thread" else ProcessPoolExecutor
     bucket = _TokenBucket(rate_limit) if rate_limit else None
+    it = iter(items)
+    index = 0
 
     pool = pool_cls(max_workers=workers)
     try:
-        for chunk in _make_chunks(n, batch_size):
+        while True:
+            # Consume one chunk from the iterable lazily
+            chunk_items: list[tuple[int, Any]] = []
+            for item in it:
+                chunk_items.append((index, item))
+                index += 1
+                if batch_size is not None and len(chunk_items) >= batch_size:
+                    break
+            if not chunk_items:
+                break
+
             futures: dict[Future[R], int] = {}
-            for i in chunk:
+            for i, item in chunk_items:
                 if bucket:
                     bucket.wait()
-                futures[pool.submit(task_fn, items_list[i])] = i
+                futures[pool.submit(task_fn, item)] = i
 
             for future in as_completed(futures):
                 idx = futures[future]

--- a/tests/test_starmap.py
+++ b/tests/test_starmap.py
@@ -1,0 +1,171 @@
+"""Tests for parallel_starmap — multi-argument parallel execution."""
+
+import time
+
+import pytest
+
+from pyarallel import parallel_map, RateLimit
+from pyarallel.core import Retry
+
+
+def _add(a, b):
+    return a + b
+
+
+class TestStarmapBasic:
+    def test_unpacks_tuples(self):
+        from pyarallel import parallel_starmap
+
+        result = parallel_starmap(_add, [(1, 2), (3, 4), (5, 6)], workers=2)
+        assert list(result) == [3, 7, 11]
+
+    def test_preserves_order(self):
+        from pyarallel import parallel_starmap
+
+        def slow_add(a, b):
+            if a == 0:
+                time.sleep(0.05)
+            return a + b
+
+        result = parallel_starmap(slow_add, [(0, 1), (2, 3), (4, 5)], workers=3)
+        assert list(result) == [1, 5, 9]
+
+    def test_empty_input(self):
+        from pyarallel import parallel_starmap
+
+        result = parallel_starmap(_add, [])
+        assert list(result) == []
+
+    def test_single_item(self):
+        from pyarallel import parallel_starmap
+
+        result = parallel_starmap(_add, [(10, 20)])
+        assert list(result) == [30]
+
+    def test_works_with_kwargs_in_tuples(self):
+        """Items can be dicts for kwargs unpacking."""
+        from pyarallel import parallel_starmap
+
+        def greet(name, greeting="Hello"):
+            return f"{greeting}, {name}!"
+
+        result = parallel_starmap(
+            greet,
+            [("Alice",), ("Bob",)],
+            workers=2,
+        )
+        assert list(result) == ["Hello, Alice!", "Hello, Bob!"]
+
+    def test_three_args(self):
+        from pyarallel import parallel_starmap
+
+        def add3(a, b, c):
+            return a + b + c
+
+        result = parallel_starmap(add3, [(1, 2, 3), (4, 5, 6)], workers=2)
+        assert list(result) == [6, 15]
+
+
+class TestStarmapErrorHandling:
+    def test_error_in_one_item(self):
+        from pyarallel import parallel_starmap
+
+        def div(a, b):
+            return a / b
+
+        result = parallel_starmap(div, [(10, 2), (10, 0), (6, 3)], workers=2)
+        assert not result.ok
+        assert len(result.failures()) == 1
+        assert len(result.successes()) == 2
+
+    def test_with_retry(self):
+        from pyarallel import parallel_starmap
+
+        call_count = {}
+
+        def flaky_add(a, b):
+            key = (a, b)
+            call_count[key] = call_count.get(key, 0) + 1
+            if call_count[key] < 2:
+                raise ValueError("not yet")
+            return a + b
+
+        result = parallel_starmap(
+            flaky_add, [(1, 2), (3, 4)], workers=2,
+            retry=Retry(attempts=3, backoff=0, jitter=False),
+        )
+        assert result.ok
+        assert list(result) == [3, 7]
+
+
+class TestStarmapWithOptions:
+    def test_with_rate_limit(self):
+        from pyarallel import parallel_starmap
+
+        start = time.monotonic()
+        parallel_starmap(
+            _add, [(1, 2)] * 5, workers=5,
+            rate_limit=RateLimit(10, "second"),
+        )
+        assert time.monotonic() - start >= 0.3
+
+    def test_with_batch_size(self):
+        from pyarallel import parallel_starmap
+
+        result = parallel_starmap(
+            _add, [(i, i) for i in range(20)], workers=4, batch_size=5,
+        )
+        assert list(result) == [i * 2 for i in range(20)]
+
+
+class TestStarmapDecorator:
+    def test_decorator_stream_has_starmap(self):
+        """@parallel decorated functions should have .starmap() too."""
+        from pyarallel import parallel
+
+        @parallel(workers=2)
+        def add(a, b):
+            return a + b
+
+        result = add.starmap([(1, 2), (3, 4)])
+        assert list(result) == [3, 7]
+
+
+class TestAsyncStarmap:
+    async def test_basic(self):
+        from pyarallel import async_parallel_starmap
+
+        async def add(a, b):
+            return a + b
+
+        result = await async_parallel_starmap(add, [(1, 2), (3, 4)], concurrency=2)
+        assert list(result) == [3, 7]
+
+    async def test_with_retry(self):
+        from pyarallel import async_parallel_starmap
+
+        call_count = {}
+
+        async def flaky_add(a, b):
+            key = (a, b)
+            call_count[key] = call_count.get(key, 0) + 1
+            if call_count[key] < 2:
+                raise ValueError("not yet")
+            return a + b
+
+        result = await async_parallel_starmap(
+            flaky_add, [(1, 2), (3, 4)], concurrency=2,
+            retry=Retry(attempts=3, backoff=0, jitter=False),
+        )
+        assert result.ok
+        assert list(result) == [3, 7]
+
+    async def test_async_decorator_starmap(self):
+        from pyarallel import async_parallel
+
+        @async_parallel(concurrency=2)
+        async def add(a, b):
+            return a + b
+
+        result = await add.starmap([(1, 2), (3, 4)])
+        assert list(result) == [3, 7]

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,179 @@
+"""Tests for parallel_iter / .stream() — streaming results, constant memory."""
+
+import threading
+import time
+
+import pytest
+
+from pyarallel import RateLimit
+from pyarallel.core import Retry
+
+
+class TestParallelIterBasic:
+    def test_yields_index_and_value(self):
+        from pyarallel import parallel_iter
+
+        results = list(parallel_iter(lambda x: x * 2, [1, 2, 3], workers=2))
+        # Results come in completion order, so sort by index
+        results.sort()
+        assert results == [(0, 2), (1, 4), (2, 6)]
+
+    def test_empty_input(self):
+        from pyarallel import parallel_iter
+
+        assert list(parallel_iter(lambda x: x, [])) == []
+
+    def test_single_item(self):
+        from pyarallel import parallel_iter
+
+        results = list(parallel_iter(lambda x: x * 10, [5], workers=1))
+        assert results == [(0, 50)]
+
+    def test_accepts_any_iterable(self):
+        from pyarallel import parallel_iter
+
+        results = list(parallel_iter(lambda x: x, range(4), workers=2))
+        assert sorted(results) == [(0, 0), (1, 1), (2, 2), (3, 3)]
+
+
+class TestParallelIterStreaming:
+    def test_constant_memory_with_batching(self):
+        """With batch_size, only one batch of results exists at a time."""
+        from pyarallel import parallel_iter
+
+        yielded_count = 0
+        for index, value in parallel_iter(
+            lambda x: x * 2, range(20), workers=2, batch_size=5,
+        ):
+            yielded_count += 1
+
+        assert yielded_count == 20
+
+    def test_results_in_completion_order(self):
+        """Without batching, fast tasks yield before slow ones."""
+        from pyarallel import parallel_iter
+
+        def speed_varies(x):
+            if x == 0:
+                time.sleep(0.1)
+            return x
+
+        results = list(parallel_iter(speed_varies, [0, 1, 2], workers=3))
+        indices = [i for i, _ in results]
+        # Index 0 should come last (it sleeps)
+        assert indices[-1] == 0
+
+
+class TestParallelIterErrors:
+    def test_errors_yielded_as_exceptions(self):
+        from pyarallel import parallel_iter
+
+        def maybe_fail(x):
+            if x == 2:
+                raise ValueError("bad")
+            return x
+
+        results = list(parallel_iter(maybe_fail, [1, 2, 3], workers=2))
+        successes = [(i, v) for i, v in results if not isinstance(v, Exception)]
+        failures = [(i, v) for i, v in results if isinstance(v, Exception)]
+
+        assert len(successes) == 2
+        assert len(failures) == 1
+        assert isinstance(failures[0][1], ValueError)
+
+    def test_errors_with_retry(self):
+        from pyarallel import parallel_iter
+
+        call_count = {}
+
+        def flaky(x):
+            call_count[x] = call_count.get(x, 0) + 1
+            if call_count[x] < 2:
+                raise ValueError("not yet")
+            return x * 10
+
+        results = list(parallel_iter(
+            flaky, [1, 2], workers=2,
+            retry=Retry(attempts=3, backoff=0, jitter=False),
+        ))
+        results.sort()
+        assert results == [(0, 10), (1, 20)]
+
+
+class TestParallelIterWithOptions:
+    def test_with_rate_limit(self):
+        from pyarallel import parallel_iter
+
+        start = time.monotonic()
+        list(parallel_iter(
+            lambda x: x, range(5), workers=5,
+            rate_limit=RateLimit(10, "second"),
+        ))
+        assert time.monotonic() - start >= 0.3
+
+    def test_with_batch_size(self):
+        from pyarallel import parallel_iter
+
+        results = list(parallel_iter(
+            lambda x: x * 2, range(15), workers=3, batch_size=5,
+        ))
+        results.sort()
+        assert results == [(i, i * 2) for i in range(15)]
+
+
+class TestDecoratorStream:
+    def test_stream_method(self):
+        from pyarallel import parallel
+
+        @parallel(workers=2)
+        def double(x):
+            return x * 2
+
+        results = list(double.stream([1, 2, 3]))
+        results.sort()
+        assert results == [(0, 2), (1, 4), (2, 6)]
+
+    def test_instance_method_stream(self):
+        from pyarallel import parallel
+
+        class Mul:
+            def __init__(self, factor):
+                self.factor = factor
+
+            @parallel(workers=2)
+            def go(self, x):
+                return x * self.factor
+
+        m = Mul(3)
+        results = list(m.go.stream([1, 2, 3]))
+        results.sort()
+        assert results == [(0, 3), (1, 6), (2, 9)]
+
+
+class TestAsyncParallelIter:
+    async def test_basic(self):
+        from pyarallel import async_parallel_iter
+
+        async def double(x):
+            return x * 2
+
+        results = []
+        async for index, value in async_parallel_iter(double, [1, 2, 3], concurrency=2):
+            results.append((index, value))
+
+        results.sort()
+        assert results == [(0, 2), (1, 4), (2, 6)]
+
+    async def test_async_decorator_stream(self):
+        from pyarallel import async_parallel
+
+        @async_parallel(concurrency=2)
+        async def double(x):
+            return x * 2
+
+        results = []
+        async for index, value in double.stream([1, 2, 3]):
+            results.append((index, value))
+
+        results.sort()
+        assert results == [(0, 2), (1, 4), (2, 6)]


### PR DESCRIPTION
## Summary

Two new features that complete the "Near Term" roadmap:

### starmap — multi-argument parallel execution
```python
def add(a, b): return a + b
parallel_starmap(add, [(1, 2), (3, 4)])  # ParallelResult([3, 7])

@parallel(workers=4)
def add(a, b): return a + b
add.starmap([(1, 2), (3, 4)])            # same
```

### streaming — constant memory results
```python
# 10M items — only one batch in memory at a time
for index, value in parallel_iter(process, huge_list, batch_size=1000):
    db.save(value)  # yielded and discarded — no accumulation

@parallel(workers=8)
def process(item): ...
for index, value in process.stream(huge_list, batch_size=1000):
    db.save(value)
```

### API surface

| Function | Decorator method | Returns | Use case |
|---|---|---|---|
| `parallel_map` | `.map()` | `ParallelResult` | Results fit in memory |
| `parallel_starmap` | `.starmap()` | `ParallelResult` | Multi-arg, fits in memory |
| `parallel_iter` | `.stream()` | `Iterator[(int, T\|Exc)]` | Streaming, constant memory |

All three have async variants (`async_parallel_map`, `async_parallel_starmap`, `async_parallel_iter`).

All options compose: retry, rate_limit, batch_size work with all three.

## Test plan

- [x] 139 tests passing (28 new: 14 starmap + 14 streaming)
- [x] starmap: basic, ordering, errors, retry, rate limit, batch_size, decorator, async
- [x] streaming: yields (index, value), completion order, errors as exceptions, retry, batch_size, decorator .stream(), instance methods, async generator
- [x] All existing tests unchanged

https://claude.ai/code/session_01RHTs4at74CA2wwTTQWQo52
