### PR TITLE
Fix process decorators and refresh examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Pyarallel is a Python library for parallel execution, designed to make concurrent programming easy and efficient. It uses a decorator-based API and supports both thread-based (for I/O-bound tasks) and process-based (for CPU-bound tasks) parallelism. Key features include rate limiting, batch processing, and a flexible configuration system.
+
+## Code Architecture
+
+The core of Pyarallel revolves around the `@parallel` decorator (`pyarallel/core.py`) which wraps functions to enable parallel execution.
+
+Configuration is managed by the `ConfigManager` (`pyarallel/config_manager.py`), a singleton class that handles global settings. It supports updates via Python code and environment variables. Configuration settings are structured into categories like `execution`, `rate_limiting`, `error_handling`, and `monitoring`. Environment variables use the `PYARALLEL_` prefix (e.g., `PYARALLEL_MAX_WORKERS`).
+
+Rate limiting logic is implemented in `pyarallel/core.py` and utilizes a `TokenBucket` class.
+
+The library supports various callable types, including regular functions, instance methods, class methods, and static methods.
+
+## Common Commands
+
+### Setup Development Environment
+```bash
+# Clone the repository
+git clone https://github.com/oneryalcin/pyarallel.git
+cd pyarallel
+
+# Install development dependencies
+pip install -e ".[dev]"
+```
+
+### Running Tests
+```bash
+# Run the full test suite
+make test
+# or
+pytest tests/ -v
+```
+To run a single test file:
+```bash
+pytest tests/test_pyarallel.py -v
+```
+To run a specific test case:
+```bash
+pytest tests/test_pyarallel.py::test_basic_parallel_processing -v
+```
+
+### Formatting Code
+```bash
+make format
+# This runs:
+# ruff format .
+# ruff check --fix .
+```
+
+### Linting (Type Checking)
+```bash
+make lint
+# This runs:
+# ruff check .
+# mypy pyarallel/
+```
+
+### Building the Package
+```bash
+make build
+# This cleans previous build artifacts and then runs:
+# python -m build
+```
+
+### Publishing the Package (to PyPI)
+```bash
+make publish
+# This first runs 'make build', then:
+# twine upload dist/*
+```
+
+### Building and Serving Documentation Locally
+```bash
+make docs-serve
+# This runs:
+# mkdocs serve
+```
+
+### Deploying Documentation to GitHub Pages
+```bash
+make docs-deploy
+# This updates the version in mkdocs.yml and then runs:
+# mkdocs gh-deploy
+```
+
+## Development Guidelines
+
+- Follow the coding style enforced by Black (line length 88 characters).
+- Use type hints for function arguments and return values.
+- Write docstrings for all public functions and classes.
+- Add tests for new code and ensure the test suite passes (`make test`).
+- Update documentation if APIs are changed.
+- Ensure code lints successfully (`make lint`).

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ help:
 	@echo "  make test         Run pytest suite"
 	@echo "  make docs-serve   Start mkdocs development server"
 	@echo "  make docs-deploy  Deploy documentation to GitHub Pages"
-	@echo "  make format      Format code with black and isort"
-	@echo "  make lint        Run mypy for type checking"
+	@echo "  make format      Format code with ruff"
+	@echo "  make lint        Run ruff check + mypy"
 	@echo "  make clean       Remove build artifacts"
 	@echo "  make build       Build package"
 	@echo "  make publish     Publish package to PyPI"
@@ -22,10 +22,11 @@ docs-deploy:
 	uv run mkdocs gh-deploy
 
 format:
-	uv run black .
-	uv run isort .
+	uv run ruff format .
+	uv run ruff check --fix .
 
 lint:
+	uv run ruff check .
 	uv run mypy pyarallel/
 
 clean:

--- a/examples/01_basic_usage.py
+++ b/examples/01_basic_usage.py
@@ -3,10 +3,10 @@
 Basic Usage Example
 ===================
 
-This example demonstrates the fundamental concepts of pyarallel:
-1. Write a function that processes ONE item
-2. Decorate it with @parallel
-3. Pass MANY items to process them in parallel
+This example demonstrates the current pyarallel API:
+1. Write a function that handles ONE item
+2. Decorate it with @parallel for reusable defaults
+3. Use .map(...) for parallel execution over MANY items
 
 Run with: python examples/01_basic_usage.py
 """
@@ -16,58 +16,45 @@ import time
 from pyarallel import parallel
 
 
-# Example 1: Simple multiplication
-# ---------------------------------
-# Notice: The function takes a SINGLE number, not a list
-@parallel(max_workers=4)
+@parallel(workers=4)
 def multiply_by_two(number):
     """Process a single number."""
     return number * 2
 
 
-print("Example 1: Simple multiplication")
+print("Example 1: Direct call vs .map()")
 print("=" * 50)
 
-# Single item - returns a list with one result
-result = multiply_by_two(5)
-print(f"multiply_by_two(5) = {result}")  # Output: [10]
+single = multiply_by_two(5)
+print(f"multiply_by_two(5) = {single}")  # Scalar return value
 
-# Multiple items - processes in parallel
-numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-results = multiply_by_two(numbers)
-print(f"multiply_by_two({numbers}) = {results}")
+numbers = [1, 2, 3, 4, 5]
+parallel_result = multiply_by_two.map(numbers)
+print(f"multiply_by_two.map({numbers}) = {list(parallel_result)}")
 print()
 
 
-# Example 2: I/O simulation with timing
-# --------------------------------------
-@parallel(max_workers=4)
+@parallel(workers=4)
 def simulate_io_task(task_id):
-    """Simulate an I/O-bound task (like API call or file read)."""
-    time.sleep(0.5)  # Simulate network delay
+    """Simulate an I/O-bound task such as an HTTP request."""
+    time.sleep(0.2)
     return f"Task {task_id} completed"
 
 
-print("Example 2: I/O simulation")
+print("Example 2: Parallel I/O")
 print("=" * 50)
 
-# Sequential execution would take 5 seconds (10 tasks × 0.5s)
-# Parallel execution with 4 workers takes ~1.5 seconds
 start = time.time()
-tasks = list(range(10))
-results = simulate_io_task(tasks)
+tasks = list(range(8))
+results = simulate_io_task.map(tasks)
 duration = time.time() - start
 
 print(f"Processed {len(results)} tasks in {duration:.2f} seconds")
-print(f"Results: {results[:3]}...")  # Show first 3 results
-print(f"Expected time (sequential): ~5 seconds")
-print(f"Actual time (parallel): {duration:.2f} seconds")
+print(f"First 3 results: {list(results)[:3]}")
 print()
 
 
-# Example 3: Data transformation
-# -------------------------------
-@parallel(max_workers=4)
+@parallel(workers=4)
 def format_name(name):
     """Format a single name to title case."""
     return name.strip().title()
@@ -77,21 +64,18 @@ print("Example 3: Data transformation")
 print("=" * 50)
 
 names = ["john doe", "JANE SMITH", "  bob jones  ", "alice wonder"]
-formatted = format_name(names)
+formatted = format_name.map(names)
 print(f"Original: {names}")
-print(f"Formatted: {formatted}")
+print(f"Formatted: {list(formatted)}")
 print()
 
 
-# Example 4: Working with instance methods
-# -----------------------------------------
 class TextProcessor:
     def __init__(self, prefix):
         self.prefix = prefix
 
-    @parallel(max_workers=4)
+    @parallel(workers=4)
     def add_prefix(self, text):
-        """Process a single text item."""
         return f"{self.prefix}: {text}"
 
 
@@ -100,16 +84,15 @@ print("=" * 50)
 
 processor = TextProcessor("LOG")
 messages = ["Starting", "Processing", "Finished"]
-prefixed = processor.add_prefix(messages)
+prefixed = processor.add_prefix.map(messages)
 print(f"Original: {messages}")
-print(f"Prefixed: {prefixed}")
+print(f"Prefixed: {list(prefixed)}")
 print()
 
 
 print("Summary")
 print("=" * 50)
-print("Key takeaways:")
-print("1. Write functions for ONE item (singular)")
-print("2. Pass MANY items (list/tuple) to process in parallel")
-print("3. Always get a list back, even for single items")
-print("4. Works with regular functions, instance methods, class methods")
+print("1. Decorated functions keep normal single-item behavior.")
+print("2. Use .map(...) to parallelize over many items.")
+print("3. .map(...) returns ParallelResult, which behaves like a list on success.")
+print("4. Methods work the same way as regular functions.")

--- a/examples/02_api_calls_with_rate_limiting.py
+++ b/examples/02_api_calls_with_rate_limiting.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 """
 API Calls with Rate Limiting
-=============================
+============================
 
-This example demonstrates how to use pyarallel for making parallel API calls
-with rate limiting to respect API quotas.
-
-Note: This example uses a mock API for demonstration.
-Replace with actual API calls for real usage.
+This example demonstrates parallel I/O with rate limits that match the
+current pyarallel API.
 
 Run with: python examples/02_api_calls_with_rate_limiting.py
 """
@@ -18,23 +15,19 @@ import time
 from pyarallel import RateLimit, parallel
 
 
-# Mock API function (simulates HTTP request)
 def mock_api_get(url):
     """Simulate an API call with network delay."""
-    time.sleep(0.1)  # Simulate network latency
+    time.sleep(0.1)
     return {
         "url": url,
         "status": "success",
-        "timestamp": time.time(),
+        "timestamp": round(time.time(), 3),
         "data": f"Data from {url}",
     }
 
 
-# Example 1: Basic API calls with threads
-# ----------------------------------------
-@parallel(max_workers=5)
+@parallel(workers=5)
 def fetch_data(endpoint_id):
-    """Fetch data from a single API endpoint."""
     url = f"https://api.example.com/data/{endpoint_id}"
     return mock_api_get(url)
 
@@ -43,20 +36,17 @@ print("Example 1: Basic parallel API calls")
 print("=" * 50)
 
 start = time.time()
-endpoint_ids = list(range(20))
-results = fetch_data(endpoint_ids)
+endpoint_ids = list(range(10))
+results = fetch_data.map(endpoint_ids)
 duration = time.time() - start
 
 print(f"Fetched {len(results)} endpoints in {duration:.2f} seconds")
-print(f"First result: {json.dumps(results[0], indent=2)}")
+print(f"First result: {json.dumps(list(results)[0], indent=2)}")
 print()
 
 
-# Example 2: Rate limited API calls (10 requests per second)
-# -----------------------------------------------------------
-@parallel(max_workers=5, rate_limit=10)  # 10 operations per second
+@parallel(workers=5, rate_limit=10)
 def fetch_with_rate_limit(endpoint_id):
-    """Fetch with rate limiting - respects API quotas."""
     url = f"https://api.example.com/limited/{endpoint_id}"
     return mock_api_get(url)
 
@@ -65,99 +55,74 @@ print("Example 2: Rate limited API calls (10/second)")
 print("=" * 50)
 
 start = time.time()
-endpoint_ids = list(range(30))
-results = fetch_with_rate_limit(endpoint_ids)
+results = fetch_with_rate_limit.map(range(12))
 duration = time.time() - start
 
 print(f"Fetched {len(results)} endpoints in {duration:.2f} seconds")
-print(f"Expected minimum time: ~3 seconds (30 requests ÷ 10 per second)")
-print(f"Actual time: {duration:.2f} seconds")
+print("Expected minimum time: about 1.1 seconds")
 print()
 
 
-# Example 3: Per-minute rate limiting
-# ------------------------------------
-@parallel(max_workers=10, rate_limit=(100, "minute"))  # 100 operations per minute
+@parallel(workers=4, rate_limit=RateLimit(120, "minute"))
 def fetch_premium_api(resource_id):
-    """Fetch from API with per-minute quota."""
     url = f"https://api.premium.com/v1/resource/{resource_id}"
     return mock_api_get(url)
 
 
-print("Example 3: Per-minute rate limiting")
+print("Example 3: Per-minute rate limit")
 print("=" * 50)
 
-# Fetch 20 items with 100/minute limit
 start = time.time()
-resource_ids = list(range(20))
-results = fetch_premium_api(resource_ids)
+results = fetch_premium_api.map(range(5))
 duration = time.time() - start
 
 print(f"Fetched {len(results)} resources in {duration:.2f} seconds")
-print(f"Rate: ~{len(results) / duration:.1f} requests/second")
+print("Rate limit: 120/minute (2 requests/second)")
 print()
 
 
-# Example 4: Using RateLimit object for clarity
-# ----------------------------------------------
-api_rate = RateLimit(count=5, interval="second")
+api_rate = RateLimit(5, "second")
 
 
-@parallel(max_workers=3, rate_limit=api_rate)
+@parallel(workers=3, rate_limit=api_rate)
 def fetch_with_rate_object(item_id):
-    """Fetch using RateLimit object for better readability."""
     url = f"https://api.example.com/items/{item_id}"
     return mock_api_get(url)
 
 
-print("Example 4: Using RateLimit object")
+print("Example 4: Using a RateLimit object")
 print("=" * 50)
 
 start = time.time()
-item_ids = list(range(15))
-results = fetch_with_rate_object(item_ids)
+results = fetch_with_rate_object.map(range(8))
 duration = time.time() - start
 
 print(f"Fetched {len(results)} items in {duration:.2f} seconds")
-print(f"Rate limit: {api_rate.count} per {api_rate.interval}")
-print(f"Expected minimum time: ~3 seconds (15 items ÷ 5 per second)")
-print(f"Actual time: {duration:.2f} seconds")
+print(f"Rate limit: {api_rate.count} per {api_rate.per}")
 print()
 
 
-# Example 5: Batch processing with rate limiting
-# -----------------------------------------------
-@parallel(
-    max_workers=4, batch_size=5, rate_limit=(10, "second")  # Process in batches of 5
-)
+@parallel(workers=4, rate_limit=RateLimit(10, "second"))
 def fetch_large_dataset(page_id):
-    """Fetch pages from a large dataset."""
     url = f"https://api.example.com/pages/{page_id}"
     return mock_api_get(url)
 
 
-print("Example 5: Batch processing with rate limiting")
+print("Example 5: Batching plus rate limiting")
 print("=" * 50)
 
 start = time.time()
-page_ids = list(range(50))
-results = fetch_large_dataset(page_ids)
+results = fetch_large_dataset.map(range(20), batch_size=5)
 duration = time.time() - start
 
 print(f"Fetched {len(results)} pages in {duration:.2f} seconds")
-print(f"Batch size: 5, Rate limit: 10/second")
+print("Batch size: 5, Rate limit: 10/second")
 print()
 
 
 print("Summary")
 print("=" * 50)
-print("Rate limiting options:")
-print("  1. @parallel(rate_limit=10)           # 10 per second")
-print("  2. @parallel(rate_limit=(100, 'minute'))  # 100 per minute")
-print("  3. @parallel(rate_limit=(1000, 'hour'))   # 1000 per hour")
-print("  4. @parallel(rate_limit=RateLimit(5, 'second'))  # Using object")
-print()
-print("Use rate limiting to:")
-print("  - Respect API quotas and avoid throttling")
-print("  - Control resource consumption")
-print("  - Ensure smooth, predictable load on external services")
+print("1. Use a numeric rate limit for requests/second.")
+print("2. Use RateLimit(count, 'minute' | 'hour') for longer windows.")
+print("3. Put reusable defaults on the decorator.")
+print("4. Pass batch_size on .map(...) when you need memory control.")

--- a/examples/03_cpu_bound_processing.py
+++ b/examples/03_cpu_bound_processing.py
@@ -3,13 +3,9 @@
 CPU-Bound Processing
 ====================
 
-This example demonstrates using pyarallel for CPU-intensive tasks
-using process-based parallelism to bypass Python's Global Interpreter Lock (GIL).
+This example compares thread and process execution for CPU-heavy work.
 
 Run with: python examples/03_cpu_bound_processing.py
-
-Note: Process-based functions must be defined at module level (not inside if __name__)
-to be picklable. All execution code is wrapped in if __name__ == "__main__".
 """
 
 import hashlib
@@ -18,110 +14,40 @@ import time
 from pyarallel import parallel
 
 
-# Example 1: Comparison - Threads vs Processes
-# ---------------------------------------------
 def compute_intensive_task(n):
-    """CPU-intensive task: calculate hash of concatenated numbers."""
+    """Small but real CPU-heavy task."""
     result = ""
     for i in range(n):
         result += str(i)
 
-    # Hash it multiple times to make it CPU-intensive
-    for _ in range(1000):
+    for _ in range(250):
         result = hashlib.sha256(result.encode()).hexdigest()
 
-    return result[:16]  # Return first 16 chars
+    return result[:16]
 
 
-# Using THREADS (not ideal for CPU-bound tasks due to GIL)
-@parallel(max_workers=4, executor_type="thread")
-def compute_with_threads(n):
-    """CPU task with threads - limited by GIL."""
-    return compute_intensive_task(n)
-
-
-# Using PROCESSES (ideal for CPU-bound tasks)
-@parallel(max_workers=4, executor_type="process")
-def compute_with_processes(n):
-    """CPU task with processes - bypasses GIL."""
-    return compute_intensive_task(n)
-
-
-if __name__ == "__main__":
-    print("Example 1: Threads vs Processes for CPU-bound tasks")
-    print("=" * 50)
-
-    numbers = [5000, 5000, 5000, 5000]
-
-    # Test with threads
-    start = time.time()
-    results_threads = compute_with_threads(numbers)
-    thread_time = time.time() - start
-
-    # Test with processes
-    start = time.time()
-    results_processes = compute_with_processes(numbers)
-    process_time = time.time() - start
-
-    print(f"Thread-based execution: {thread_time:.2f} seconds")
-    print(f"Process-based execution: {process_time:.2f} seconds")
-    print(f"Speedup with processes: {thread_time / process_time:.2f}x faster")
-    print()
-
-
-# Example 2: Image processing simulation
-# ---------------------------------------
 def process_image_data(image_id):
-    """Simulate CPU-intensive image processing."""
-    # Simulate image transformations (resize, filter, etc.)
-    data = bytearray(range(256)) * 100  # Simulate image data
-
-    # Simulate complex transformations
-    for _ in range(10000):
-        # Simulate filters/transformations
+    data = bytearray(range(128)) * 40
+    for _ in range(1000):
         data = bytearray([b ^ 0xFF for b in data])
         data = bytearray([b >> 1 for b in data])
-
     return f"image_{image_id}_processed.jpg"
 
 
-@parallel(max_workers=4, executor_type="process")
-def process_images(image_id):
-    """Process image using multiple CPU cores."""
-    return process_image_data(image_id)
-
-
-# Example 3: Data analysis / number crunching
-# --------------------------------------------
 def analyze_dataset(dataset_id):
-    """Simulate data analysis on a dataset."""
-    # Generate some "data"
-    data = [i * 1.5 for i in range(50000)]
-
-    # Perform calculations
+    data = [i * 1.5 for i in range(15000)]
     total = sum(data)
     mean = total / len(data)
     variance = sum((x - mean) ** 2 for x in data) / len(data)
-    std_dev = variance**0.5
-
     return {
         "dataset_id": dataset_id,
         "count": len(data),
         "mean": round(mean, 2),
-        "std_dev": round(std_dev, 2),
+        "std_dev": round(variance**0.5, 2),
     }
 
 
-@parallel(max_workers=4, executor_type="process")
-def analyze_datasets(dataset_id):
-    """Analyze multiple datasets in parallel."""
-    return analyze_dataset(dataset_id)
-
-
-# Example 4: Prime number calculation
-# ------------------------------------
 def is_prime(n):
-    """Check if a number is prime (CPU-intensive for large numbers)."""
     if n < 2:
         return False
     if n == 2:
@@ -129,7 +55,6 @@ def is_prime(n):
     if n % 2 == 0:
         return False
 
-    # Check odd divisors up to sqrt(n)
     i = 3
     while i * i <= n:
         if n % i == 0:
@@ -138,56 +63,79 @@ def is_prime(n):
     return True
 
 
-@parallel(max_workers=4, executor_type="process")
+@parallel(workers=4, executor="thread")
+def compute_with_threads(n):
+    return compute_intensive_task(n)
+
+
+@parallel(workers=4, executor="process")
+def compute_with_processes(n):
+    return compute_intensive_task(n)
+
+
+@parallel(workers=4, executor="process")
+def process_images(image_id):
+    return process_image_data(image_id)
+
+
+@parallel(workers=4, executor="process")
+def analyze_datasets(dataset_id):
+    return analyze_dataset(dataset_id)
+
+
+@parallel(workers=4, executor="process")
 def check_prime(n):
-    """Check if a number is prime using parallel processing."""
     return (n, is_prime(n))
 
 
 if __name__ == "__main__":
-    # Continue from Example 1...
+    print("Example 1: Threads vs Processes for CPU-bound tasks")
+    print("=" * 50)
+
+    numbers = [3000, 3000, 3000, 3000]
+
+    start = time.time()
+    thread_results = compute_with_threads.map(numbers)
+    thread_time = time.time() - start
+
+    start = time.time()
+    process_results = compute_with_processes.map(numbers)
+    process_time = time.time() - start
+
+    print(f"Thread-based execution: {thread_time:.2f} seconds")
+    print(f"Process-based execution: {process_time:.2f} seconds")
+    print(f"Thread sample: {list(thread_results)[0]}")
+    print(f"Process sample: {list(process_results)[0]}")
+    print()
 
     print("Example 2: Batch image processing")
     print("=" * 50)
 
     start = time.time()
-    image_ids = list(range(12))
-    processed_images = process_images(image_ids)
+    image_results = process_images.map(range(6))
     duration = time.time() - start
 
-    print(f"Processed {len(processed_images)} images in {duration:.2f} seconds")
-    print(f"Throughput: {len(processed_images) / duration:.1f} images/second")
-    print(f"Results: {processed_images[:3]}...")
+    print(f"Processed {len(image_results)} images in {duration:.2f} seconds")
+    print(f"Results: {list(image_results)[:3]}...")
     print()
 
     print("Example 3: Parallel data analysis")
     print("=" * 50)
 
     start = time.time()
-    dataset_ids = list(range(8))
-    analyses = analyze_datasets(dataset_ids)
+    analyses = analyze_datasets.map(range(4))
     duration = time.time() - start
 
     print(f"Analyzed {len(analyses)} datasets in {duration:.2f} seconds")
-    print(f"Sample result: {analyses[0]}")
+    print(f"Sample result: {list(analyses)[0]}")
     print()
 
     print("Example 4: Prime number checking")
     print("=" * 50)
 
-    # Check primality of large numbers
+    large_numbers = [1000003, 1000033, 1000037, 1000039]
     start = time.time()
-    large_numbers = [
-        1000003,
-        1000033,
-        1000037,
-        1000039,
-        1000081,
-        1000099,
-        1000117,
-        1000121,
-    ]
-    results = check_prime(large_numbers)
+    results = check_prime.map(large_numbers)
     duration = time.time() - start
 
     print(f"Checked {len(results)} numbers in {duration:.2f} seconds")
@@ -197,19 +145,6 @@ if __name__ == "__main__":
 
     print("Summary")
     print("=" * 50)
-    print("When to use executor_type='process':")
-    print("  ✓ CPU-intensive calculations")
-    print("  ✓ Data processing and transformations")
-    print("  ✓ Image/video processing")
-    print("  ✓ Scientific computing")
-    print("  ✓ Cryptographic operations")
-    print()
-    print("When to use executor_type='thread' (default):")
-    print("  ✓ I/O-bound tasks (network, disk)")
-    print("  ✓ API calls")
-    print("  ✓ Database queries")
-    print("  ✓ File operations")
-    print()
-    print("Key insight:")
-    print("  Process-based parallelism bypasses Python's GIL,")
-    print("  enabling true parallel CPU utilization across cores.")
+    print("1. Use executor='process' for CPU-heavy work.")
+    print("2. Keep process functions at module scope so they stay picklable.")
+    print("3. Decorated .map(...) now works for both thread and process executors.")

--- a/examples/04_batch_processing.py
+++ b/examples/04_batch_processing.py
@@ -3,13 +3,9 @@
 Batch Processing
 ================
 
-This example demonstrates how to efficiently process large datasets
-using batch processing to control memory usage.
+This example demonstrates memory control with batch_size on .map(...).
 
 Run with: python examples/04_batch_processing.py
-
-Note: Example 5 uses process-based parallelism, so all execution code
-must be wrapped in if __name__ == "__main__" for proper pickling.
 """
 
 import time
@@ -17,194 +13,122 @@ import time
 from pyarallel import parallel
 
 
-# Example 1: Memory-efficient batch processing
-# ---------------------------------------------
-@parallel(max_workers=4, batch_size=10)
+@parallel(workers=4)
 def process_record(record_id):
-    """Process a single record from a large dataset."""
-    # Simulate processing
     time.sleep(0.01)
     return f"Record {record_id} processed"
 
 
-# Process 100 records in batches of 10
-start = time.time()
-record_ids = list(range(100))
-results = process_record(record_ids)
-duration = time.time() - start
-
-print(f"Processed {len(results)} records in {duration:.2f} seconds")
-print(f"Batch size: 10 (processes 10 items at a time)")
-print(f"Total batches: {len(results) // 10}")
-print()
-
-
-# Example 2: Comparing batch sizes
-# ---------------------------------
-def benchmark_batch_size(batch_size, total_items=200):
-    """Benchmark different batch sizes."""
-
-    @parallel(max_workers=4, batch_size=batch_size)
-    def process_item(item_id):
-        time.sleep(0.005)  # Simulate processing
-        return item_id * 2
-
-    start = time.time()
-    items = list(range(total_items))
-    results = process_item(items)
-    duration = time.time() - start
-
-    return duration
-
-
-print("Example 2: Batch size comparison")
-print("=" * 50)
-
-batch_sizes = [1, 10, 25, 50, 100]
-for batch_size in batch_sizes:
-    duration = benchmark_batch_size(batch_size)
-    print(f"Batch size {batch_size:3d}: {duration:.2f} seconds")
-
-print()
-
-
-# Example 3: Large dataset processing with memory constraints
-# ------------------------------------------------------------
-class DataLoader:
-    """Simulate loading large data objects."""
-
-    @staticmethod
-    def load_chunk(chunk_id):
-        """Simulate loading a large data chunk (e.g., from database)."""
-        # In real scenario, this might load from database/file
-        return {
-            "chunk_id": chunk_id,
-            "data": [i for i in range(1000)],  # Simulate large data
-            "size_kb": 100,
-        }
-
-
-@parallel(max_workers=4, batch_size=5)  # Small batches for memory control
+@parallel(workers=4)
 def process_large_chunk(chunk_id):
-    """Process large data chunks in controlled batches."""
-    chunk = DataLoader.load_chunk(chunk_id)
-
-    # Process the data
-    processed_data = sum(chunk["data"])
-
-    return {"chunk_id": chunk_id, "result": processed_data, "size_kb": chunk["size_kb"]}
-
-
-print("Example 3: Memory-constrained processing")
-print("=" * 50)
-
-start = time.time()
-chunk_ids = list(range(50))  # 50 large chunks
-results = process_large_chunk(chunk_ids)
-duration = time.time() - start
-
-total_size = sum(r["size_kb"] for r in results)
-print(f"Processed {len(results)} chunks ({total_size} KB total)")
-print(f"Time: {duration:.2f} seconds")
-print(f"Batch size: 5 (max 5 chunks in memory at once)")
-print(f"Memory efficiency: Only 5 chunks loaded simultaneously")
-print()
+    chunk = {
+        "chunk_id": chunk_id,
+        "data": [i for i in range(1000)],
+        "size_kb": 100,
+    }
+    return {
+        "chunk_id": chunk_id,
+        "result": sum(chunk["data"]),
+        "size_kb": chunk["size_kb"],
+    }
 
 
-# Example 4: Database-style batch processing
-# -------------------------------------------
-class DatabaseSimulator:
-    """Simulate batch database operations."""
-
-    @staticmethod
-    def fetch_user(user_id):
-        """Simulate fetching user from database."""
-        time.sleep(0.01)  # Simulate DB latency
-        return {
-            "id": user_id,
-            "name": f"User {user_id}",
-            "email": f"user{user_id}@example.com",
-        }
-
-
-@parallel(
-    max_workers=10,
-    batch_size=20,  # Process 20 users at a time
-    prewarm=True,  # Start workers immediately
-)
+@parallel(workers=10)
 def fetch_and_enrich_user(user_id):
-    """Fetch user and add enrichment data."""
-    user = DatabaseSimulator.fetch_user(user_id)
-
-    # Add enrichment
-    user["status"] = "active"
-    user["processed_at"] = time.time()
-
-    return user
-
-
-print("Example 4: Batch database operations")
-print("=" * 50)
-
-start = time.time()
-user_ids = list(range(1000))
-users = fetch_and_enrich_user(user_ids)
-duration = time.time() - start
-
-print(f"Fetched and enriched {len(users)} users")
-print(f"Time: {duration:.2f} seconds")
-print(f"Throughput: {len(users) / duration:.0f} users/second")
-print(f"Batch size: 20, Workers: 10 (prewarmed)")
-print(f"Sample: {users[0]}")
-print()
+    time.sleep(0.01)
+    return {
+        "id": user_id,
+        "name": f"User {user_id}",
+        "email": f"user{user_id}@example.com",
+        "status": "active",
+        "processed_at": round(time.time(), 3),
+    }
 
 
-# Example 5: File processing in batches
-# --------------------------------------
-@parallel(
-    max_workers=4, batch_size=50, executor_type="process"  # Process 50 files per batch
-)
+@parallel(workers=4, executor="process")
 def process_file(file_id):
-    """Simulate processing a file (e.g., CSV, log file)."""
-    # Simulate file reading and processing
     lines = [f"line {i}" for i in range(100)]
-
-    # Process lines
     processed_lines = [line.upper() for line in lines]
-
     return {"file_id": file_id, "lines_processed": len(processed_lines)}
 
 
-print("Example 5: Batch file processing")
-print("=" * 50)
+def benchmark_batch_size(batch_size, total_items=80):
+    @parallel(workers=4)
+    def process_item(item_id):
+        time.sleep(0.005)
+        return item_id * 2
 
-start = time.time()
-file_ids = list(range(500))  # 500 files
-results = process_file(file_ids)
-duration = time.time() - start
-
-total_lines = sum(r["lines_processed"] for r in results)
-print(f"Processed {len(results)} files ({total_lines:,} lines total)")
-print(f"Time: {duration:.2f} seconds")
-print(f"Files/second: {len(results) / duration:.0f}")
-print(f"Batch size: 50 (processes 50 files at a time)")
-print()
+    start = time.time()
+    results = process_item.map(range(total_items), batch_size=batch_size)
+    assert len(results) == total_items
+    return time.time() - start
 
 
-print("Summary")
-print("=" * 50)
-print("Batch processing benefits:")
-print("  ✓ Controls memory usage (limits concurrent operations)")
-print("  ✓ Prevents resource exhaustion")
-print("  ✓ Improves predictability")
-print("  ✓ Enables processing of datasets larger than RAM")
-print()
-print("Choosing batch size:")
-print("  • Small batches (5-20): Large items, limited memory")
-print("  • Medium batches (20-100): Balanced approach")
-print("  • Large batches (100+): Small items, optimize throughput")
-print()
-print("Combine with:")
-print("  • max_workers: Control concurrency")
-print("  • executor_type: Choose thread/process based on task")
-print("  • rate_limit: Control external API/resource load")
+def main():
+    print("Example 1: Memory-efficient batch processing")
+    print("=" * 50)
+
+    start = time.time()
+    results = process_record.map(range(40), batch_size=10)
+    duration = time.time() - start
+
+    print(f"Processed {len(results)} records in {duration:.2f} seconds")
+    print("Batch size: 10")
+    print()
+
+    print("Example 2: Batch size comparison")
+    print("=" * 50)
+
+    for batch_size in [1, 5, 10, 20, 40]:
+        duration = benchmark_batch_size(batch_size)
+        print(f"Batch size {batch_size:2d}: {duration:.2f} seconds")
+    print()
+
+    print("Example 3: Large dataset processing")
+    print("=" * 50)
+
+    start = time.time()
+    chunk_results = process_large_chunk.map(range(20), batch_size=5)
+    duration = time.time() - start
+    total_size = sum(r["size_kb"] for r in chunk_results)
+
+    print(f"Processed {len(chunk_results)} chunks ({total_size} KB total)")
+    print(f"Time: {duration:.2f} seconds")
+    print("Batch size: 5")
+    print()
+
+    print("Example 4: Database-style operations")
+    print("=" * 50)
+
+    start = time.time()
+    users = fetch_and_enrich_user.map(range(100), batch_size=20)
+    duration = time.time() - start
+
+    print(f"Fetched and enriched {len(users)} users")
+    print(f"Time: {duration:.2f} seconds")
+    print(f"Sample: {list(users)[0]}")
+    print()
+
+    print("Example 5: Process-based batch work")
+    print("=" * 50)
+
+    start = time.time()
+    file_results = process_file.map(range(40), batch_size=10)
+    duration = time.time() - start
+    total_lines = sum(r["lines_processed"] for r in file_results)
+
+    print(f"Processed {len(file_results)} files ({total_lines:,} lines total)")
+    print(f"Time: {duration:.2f} seconds")
+    print("Batch size: 10, executor='process'")
+    print()
+
+    print("Summary")
+    print("=" * 50)
+    print("1. Pass batch_size to .map(...) to limit in-flight work.")
+    print("2. Smaller batches reduce peak memory.")
+    print("3. Larger batches can improve throughput for tiny tasks.")
+    print("4. Batching works with both thread and process executors.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_configuration.py
+++ b/examples/05_configuration.py
@@ -1,185 +1,104 @@
 #!/usr/bin/env python3
 """
-Configuration Management
-========================
+Execution Configuration
+=======================
 
-This example demonstrates how to configure pyarallel globally
-and override settings at the decorator level.
+This example demonstrates the configuration knobs that exist today:
+- decorator defaults
+- per-call overrides
+- retry and rate limiting
+- timeout behavior
 
 Run with: python examples/05_configuration.py
 """
 
 import time
 
-from pyarallel import config, parallel
-
-print("Example 1: Default configuration")
-print("=" * 50)
-
-# Check default configuration
-current_config = config.get_config()
-print("Current configuration:")
-print(f"  Max workers: {current_config.max_workers}")
-print(f"  Timeout: {current_config.timeout}")
-print()
+from pyarallel import RateLimit, Retry, parallel, parallel_map
 
 
-# Example 2: Update global configuration
-# ---------------------------------------
-print("Example 2: Updating global configuration")
-print("=" * 50)
-
-# Update global defaults
-config.update_config(
-    {
-        "max_workers": 8,
-        "execution": {"default_executor_type": "thread", "default_batch_size": 50},
-    }
-)
-
-print("Updated configuration:")
-print(f"  Max workers: {config.get_config().max_workers}")
-print(f"  Default executor: {config.execution.default_executor_type}")
-print(f"  Default batch size: {config.execution.default_batch_size}")
-print()
-
-
-# Example 3: Functions using global config
-# -----------------------------------------
-@parallel  # Uses global configuration (8 workers)
-def process_with_defaults(item):
-    """Process using global configuration."""
-    time.sleep(0.01)
+@parallel(workers=4, rate_limit=RateLimit(20, "second"))
+def process_item(item):
+    time.sleep(0.05)
     return item * 2
 
 
-print("Example 3: Using global configuration")
-print("=" * 50)
-
-items = list(range(20))
-results = process_with_defaults(items)
-print(f"Processed {len(results)} items using global config (8 workers)")
-print()
+def flaky(item):
+    if item == 2:
+        raise ValueError("temporary failure")
+    return item * 10
 
 
-# Example 4: Override configuration at decorator level
-# -----------------------------------------------------
-@parallel(max_workers=4, batch_size=10)  # Override global settings
-def process_with_override(item):
-    """Process with decorator-level configuration."""
-    time.sleep(0.01)
-    return item * 3
-
-
-print("Example 4: Overriding global configuration")
-print("=" * 50)
-
-items = list(range(20))
-results = process_with_override(items)
-print(f"Processed {len(results)} items using decorator config (4 workers, batch 10)")
-print()
-
-
-# Example 5: Category-specific updates
-# -------------------------------------
-print("Example 5: Category-specific configuration")
-print("=" * 50)
-
-# Update execution settings
-config.update_execution(default_max_workers=16)
-
-# Update rate limiting defaults
-config.update_rate_limiting(rate=100, interval="minute")
-
-print("Updated execution config:")
-print(f"  Default max workers: {config.execution.default_max_workers}")
-print()
-print("Updated rate limiting config:")
-print(f"  Rate: {config.rate_limiting.rate}")
-print(f"  Interval: {config.rate_limiting.interval}")
-print()
-
-
-# Example 6: Configuration hierarchy
-# -----------------------------------
-print("Example 6: Configuration hierarchy")
-print("=" * 50)
-
-print("Configuration precedence (highest to lowest):")
-print("  1. Decorator arguments")
-print("  2. Environment variables (PYARALLEL_*)")
-print("  3. Global configuration (config.update_config())")
-print("  4. Built-in defaults")
-print()
-
-# Demonstrate hierarchy
-config.update_config({"max_workers": 8})  # Global config
-
-
-@parallel(max_workers=4)  # Decorator override
-def demo_hierarchy(item):
+def slow(item):
+    time.sleep(0.3)
     return item
 
 
-print("Global config sets max_workers=8")
-print("Decorator sets max_workers=4")
-print("Result: Decorator wins (max_workers=4)")
-print()
-
-
-# Example 7: Environment variable configuration
-# ----------------------------------------------
-print("Example 7: Environment variable support")
+print("Example 1: Decorator defaults")
 print("=" * 50)
 
-print("Set environment variables to configure pyarallel:")
-print()
-print("  export PYARALLEL_MAX_WORKERS=16")
-print("  export PYARALLEL_TIMEOUT=60.0")
-print("  export PYARALLEL_DEBUG=true")
-print("  export PYARALLEL_LOG_LEVEL=INFO")
-print()
-print("Environment variables are loaded at import time")
-print("and override global configuration.")
+results = process_item.map(range(6))
+print(f"Results with decorator defaults: {list(results)}")
 print()
 
 
-# Example 8: Accessing configuration values
-# ------------------------------------------
-print("Example 8: Accessing configuration")
+print("Example 2: Per-call overrides")
 print("=" * 50)
 
-# Get full configuration
-full_config = config.get_config()
+start = time.time()
+results = process_item.map(range(8), workers=2, batch_size=4)
+duration = time.time() - start
 
-print("Full configuration structure:")
-print(f"  Max workers: {full_config.max_workers}")
-print(f"  Timeout: {full_config.timeout}")
-print(f"  Debug: {full_config.debug}")
-print(f"  Log level: {full_config.log_level}")
+print(f"Results with workers=2 and batch_size=4: {list(results)}")
+print(f"Elapsed: {duration:.2f} seconds")
 print()
 
-# Access nested configuration
-print("Execution settings:")
-print(f"  Default max workers: {full_config.execution.default_max_workers}")
-print(f"  Default executor type: {full_config.execution.default_executor_type}")
-print(f"  Default batch size: {full_config.execution.default_batch_size}")
+
+print("Example 3: Direct function API")
+print("=" * 50)
+
+results = parallel_map(
+    lambda x: x + 1,
+    [10, 20, 30],
+    workers=3,
+    rate_limit=RateLimit(30, "second"),
+)
+print(f"parallel_map results: {list(results)}")
+print()
+
+
+print("Example 4: Retry")
+print("=" * 50)
+
+retry_result = parallel_map(
+    flaky,
+    [1, 2, 3],
+    workers=3,
+    retry=Retry(attempts=2, backoff=0, jitter=False),
+)
+
+print(f"Successes: {retry_result.successes()}")
+print(
+    "Failures:",
+    [(index, type(exc).__name__, str(exc)) for index, exc in retry_result.failures()],
+)
+print()
+
+
+print("Example 5: Total timeout")
+print("=" * 50)
+
+timeout_result = parallel_map(slow, [1, 2, 3], workers=3, timeout=0.1)
+print(
+    "Timeout failures:",
+    [(index, type(exc).__name__) for index, exc in timeout_result.failures()],
+)
 print()
 
 
 print("Summary")
 print("=" * 50)
-print("Configuration best practices:")
-print()
-print("1. Set global defaults at application startup:")
-print("   config.update_config({...})")
-print()
-print("2. Use environment variables for deployment:")
-print("   PYARALLEL_MAX_WORKERS=8 python app.py")
-print()
-print("3. Override at decorator level for specific needs:")
-print("   @parallel(max_workers=4, batch_size=10)")
-print()
-print("4. Use category-specific updates for clarity:")
-print("   config.update_execution(max_workers=16)")
-print("   config.update_rate_limiting(rate=100)")
+print("1. Put reusable defaults on the decorator.")
+print("2. Override workers, batch_size, and timeout on each .map(...) call.")
+print("3. Use Retry(...) for transient failures.")
+print("4. Use RateLimit(...) to control request rate.")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,119 +1,62 @@
 # Pyarallel Examples
 
-This directory contains practical, runnable examples demonstrating various features of pyarallel.
+These scripts are runnable examples for the current `pyarallel` API.
 
 ## Prerequisites
 
-Make sure pyarallel is installed:
+Install from PyPI:
 
 ```bash
 pip install pyarallel
 ```
 
-Or install from source:
+Or from source:
 
 ```bash
-cd ..
-pip install -e .
+uv sync --group dev
 ```
 
 ## Examples Overview
 
 ### 01_basic_usage.py
-**Learn the fundamentals**
 
-- How to write functions for single items
-- How to process multiple items in parallel
-- Working with instance methods
-- Understanding return values (always returns a list)
+Shows the core pattern: direct calls stay scalar, and `.map(...)` runs work in parallel.
 
 ```bash
 python examples/01_basic_usage.py
 ```
 
-**Key Concepts:**
-- Decorator-based API
-- Single item → Many items pattern
-- Method support (instance/class/static)
-
----
-
 ### 02_api_calls_with_rate_limiting.py
-**Master rate limiting for API calls**
 
-- Basic parallel API calls
-- Per-second rate limiting
-- Per-minute and per-hour limits
-- Using the RateLimit object
-- Combining batch processing with rate limits
+Shows thread-based I/O with numeric rate limits and `RateLimit(...)` objects.
 
 ```bash
 python examples/02_api_calls_with_rate_limiting.py
 ```
 
-**Key Concepts:**
-- Respecting API quotas
-- Three ways to specify rate limits
-- Smooth request distribution
-
----
-
 ### 03_cpu_bound_processing.py
-**Understand thread vs process parallelism**
 
-- Comparing threads vs processes
-- CPU-intensive tasks (image processing, number crunching)
-- When to use `executor_type="process"`
-- Bypassing Python's GIL for true parallelism
+Shows when to use `executor="process"` for CPU-heavy work.
 
 ```bash
 python examples/03_cpu_bound_processing.py
 ```
 
-**Key Concepts:**
-- Process-based parallelism for CPU tasks
-- Thread-based parallelism for I/O tasks
-- Performance comparisons
-
----
-
 ### 04_batch_processing.py
-**Efficiently handle large datasets**
 
-- Memory-efficient batch processing
-- Comparing different batch sizes
-- Database-style operations
-- Processing datasets larger than RAM
+Shows how to control memory by passing `batch_size` to `.map(...)`.
 
 ```bash
 python examples/04_batch_processing.py
 ```
 
-**Key Concepts:**
-- Controlling memory usage
-- Choosing appropriate batch sizes
-- Combining batching with other features
-
----
-
 ### 05_configuration.py
-**Configure pyarallel globally and per-function**
 
-- Global configuration management
-- Category-specific updates
-- Configuration hierarchy
-- Environment variable support
+Shows decorator defaults, per-call overrides, retry, rate limiting, and timeout behavior.
 
 ```bash
 python examples/05_configuration.py
 ```
-
-**Key Concepts:**
-- Setting global defaults
-- Override at decorator level
-- Environment variable configuration
-
----
 
 ## Quick Reference
 
@@ -122,104 +65,36 @@ python examples/05_configuration.py
 ```python
 from pyarallel import parallel
 
-# 1. Write function for ONE item
-@parallel(max_workers=4)
+@parallel(workers=4)
 def process_item(item):
     return item * 2
 
-# 2. Pass MANY items
-items = [1, 2, 3, 4, 5]
-results = process_item(items)  # [2, 4, 6, 8, 10]
+single = process_item(5)
+many = process_item.map([1, 2, 3, 4, 5])
 ```
 
 ### Common Parameters
 
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `max_workers` | Number of parallel workers | `max_workers=4` |
-| `executor_type` | "thread" or "process" | `executor_type="process"` |
-| `batch_size` | Items per batch | `batch_size=100` |
-| `rate_limit` | Limit operations/time | `rate_limit=10` or `rate_limit=(100, "minute")` |
-| `prewarm` | Start workers immediately | `prewarm=True` |
-
-### When to Use What
-
-**Threads (default):**
-- ✓ API calls
-- ✓ File I/O
-- ✓ Database queries
-- ✓ Network operations
-
-**Processes:**
-- ✓ CPU-intensive calculations
-- ✓ Data transformations
-- ✓ Image/video processing
-- ✓ Scientific computing
-
-**Batching:**
-- ✓ Large datasets
-- ✓ Memory constraints
-- ✓ Database operations
-- ✓ Rate limiting
-
-**Rate Limiting:**
-- ✓ API quotas
-- ✓ Resource protection
-- ✓ Smooth load distribution
-
----
+| Parameter | Where | Example |
+|-----------|-------|---------|
+| `workers` | `@parallel(...)` or `.map(...)` | `workers=4` |
+| `executor` | `@parallel(...)`, `.map(...)`, or `parallel_map(...)` | `executor="process"` |
+| `batch_size` | `.map(...)` | `batch_size=100` |
+| `rate_limit` | `@parallel(...)` or `.map(...)` | `rate_limit=10` or `RateLimit(100, "minute")` |
+| `retry` | `.map(...)` or `parallel_map(...)` | `retry=Retry(attempts=3)` |
+| `timeout` | `.map(...)` or `parallel_map(...)` | `timeout=30.0` |
 
 ## Running All Examples
 
-To run all examples in sequence:
-
 ```bash
 for example in examples/*.py; do
-    echo "Running $example..."
-    python "$example"
-    echo "---"
+  echo "Running $example..."
+  python "$example"
 done
 ```
 
-Or selectively:
+## Notes
 
-```bash
-# Just the basics
-python examples/01_basic_usage.py
-
-# API examples
-python examples/02_api_calls_with_rate_limiting.py
-
-# CPU examples
-python examples/03_cpu_bound_processing.py
-```
-
----
-
-## Modifying Examples
-
-Feel free to modify these examples to experiment:
-
-- Change `max_workers` to see performance differences
-- Adjust `batch_size` to understand memory tradeoffs
-- Compare `executor_type="thread"` vs `executor_type="process"`
-- Experiment with different `rate_limit` values
-
----
-
-## Need Help?
-
-- **Documentation:** https://oneryalcin.github.io/pyarallel
-- **Issues:** https://github.com/oneryalcin/pyarallel/issues
-- **PyPI:** https://pypi.org/project/pyarallel
-
----
-
-## Next Steps
-
-After running these examples:
-
-1. Read the [full documentation](https://oneryalcin.github.io/pyarallel)
-2. Check out [best practices](../docs/user-guide/best-practices.md)
-3. Explore [advanced features](../docs/user-guide/advanced-features.md)
-4. Try pyarallel in your own projects!
+- Use `.map(...)` for ordered, accumulated results.
+- Use `.stream(...)` or `parallel_iter(...)` when results should be consumed incrementally.
+- For `executor="process"`, keep worker functions at module scope.

--- a/pyarallel/__init__.py
+++ b/pyarallel/__init__.py
@@ -1,9 +1,20 @@
 """Pyarallel — simple, explicit parallel execution for Python."""
 
-from .aio import (async_parallel, async_parallel_iter, async_parallel_map,
-                  async_parallel_starmap)
-from .core import (ParallelResult, RateLimit, Retry, parallel, parallel_iter,
-                   parallel_map, parallel_starmap)
+from .aio import (
+    async_parallel,
+    async_parallel_iter,
+    async_parallel_map,
+    async_parallel_starmap,
+)
+from .core import (
+    ParallelResult,
+    RateLimit,
+    Retry,
+    parallel,
+    parallel_iter,
+    parallel_map,
+    parallel_starmap,
+)
 
 __version__ = "0.3.0"
 __all__ = [

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -7,15 +7,20 @@ Uses ``asyncio.TaskGroup`` for structured concurrency and
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
-from collections.abc import AsyncIterator
-from typing import Any, Callable, Iterable, TypeVar
+from collections.abc import AsyncIterator, Callable, Iterable
+from typing import Any
 
-from .core import (_PENDING, ParallelResult, RateLimit, Retry, _Failure,
-                   _make_chunks, _merge_opts)
-
-R = TypeVar("R")
-
+from .core import (
+    _PENDING,
+    ParallelResult,
+    RateLimit,
+    Retry,
+    _Failure,
+    _make_chunks,
+    _merge_opts,
+)
 
 # ---------------------------------------------------------------------------
 # Async rate limiter
@@ -75,7 +80,7 @@ async def _async_run_with_retry(
     raise last_exc  # type: ignore[misc]
 
 
-async def async_parallel_map(
+async def async_parallel_map[R](
     fn: Callable[..., Any],
     items: Iterable[Any],
     *,
@@ -159,7 +164,7 @@ async def async_parallel_map(
     return ParallelResult(results)
 
 
-async def async_parallel_starmap(
+async def async_parallel_starmap[R](
     fn: Callable[..., Any],
     items: Iterable[tuple[Any, ...]],
     *,
@@ -256,10 +261,8 @@ async def async_parallel_iter(
         for t in active_tasks:
             t.cancel()
         for t in active_tasks:
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await t
-            except asyncio.CancelledError:
-                pass
 
 
 # ---------------------------------------------------------------------------

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -7,6 +7,7 @@ no global config singletons, no enterprise astronautics.
 from __future__ import annotations
 
 import functools
+import importlib
 import random
 import threading
 import time
@@ -149,6 +150,47 @@ def _make_chunks(n: int, batch_size: int | None) -> list[range]:
             for start in range(0, n, batch_size)
         ]
     return [range(n)]
+
+
+def _resolve_process_target(
+    fn: Callable[..., Any],
+) -> tuple[str, str] | None:
+    """Return a module/qualname pair when *fn* can be re-imported in a worker.
+
+    This keeps process execution working for decorated top-level functions,
+    whose original function object is no longer the module-global binding.
+    """
+    if getattr(fn, "__self__", None) is not None:
+        return None
+
+    module_name = getattr(fn, "__module__", None)
+    qualname = getattr(fn, "__qualname__", None)
+    if not module_name or not qualname or "<locals>" in qualname:
+        return None
+    return (module_name, qualname)
+
+
+@functools.lru_cache(maxsize=None)
+def _load_process_target(module_name: str, qualname: str) -> Callable[..., Any]:
+    """Import and resolve a callable by module and qualname."""
+    target: Any = importlib.import_module(module_name)
+    for part in qualname.split("."):
+        target = getattr(target, part)
+    if not callable(target):
+        raise TypeError(f"{module_name}.{qualname} is not callable")
+    return target
+
+
+def _call_resolved(item: Any, *, module_name: str, qualname: str) -> Any:
+    """Resolve a callable inside the worker process and call it with one item."""
+    return _load_process_target(module_name, qualname)(item)
+
+
+def _call_resolved_args(
+    args: tuple[Any, ...], *, module_name: str, qualname: str
+) -> Any:
+    """Resolve a callable inside the worker process and call it with *args."""
+    return _load_process_target(module_name, qualname)(*args)
 
 
 # ---------------------------------------------------------------------------
@@ -306,8 +348,30 @@ def parallel_map(
         return ParallelResult([])
 
     task_fn = fn
+    if executor == "process":
+        resolved = _resolve_process_target(fn)
+        if resolved is not None:
+            module_name, qualname = resolved
+            task_fn = functools.partial(
+                _call_resolved,
+                module_name=module_name,
+                qualname=qualname,
+            )
     if retry is not None:
         task_fn = functools.partial(_run_with_retry, fn, retry=retry)
+        if executor == "process":
+            resolved = _resolve_process_target(fn)
+            if resolved is not None:
+                module_name, qualname = resolved
+                task_fn = functools.partial(
+                    _run_with_retry,
+                    functools.partial(
+                        _call_resolved,
+                        module_name=module_name,
+                        qualname=qualname,
+                    ),
+                    retry=retry,
+                )
 
     pool_cls = ThreadPoolExecutor if executor == "thread" else ProcessPoolExecutor
     bucket = _TokenBucket(rate_limit) if rate_limit else None
@@ -391,6 +455,26 @@ def parallel_starmap(
         def add(a, b): return a + b
         parallel_starmap(add, [(1, 2), (3, 4)])  # [3, 7]
     """
+    if executor == "process":
+        resolved = _resolve_process_target(fn)
+        if resolved is not None:
+            module_name, qualname = resolved
+            return parallel_map(
+                functools.partial(
+                    _call_resolved_args,
+                    module_name=module_name,
+                    qualname=qualname,
+                ),
+                items,
+                workers=workers,
+                executor=executor,
+                rate_limit=rate_limit,
+                timeout=timeout,
+                on_progress=on_progress,
+                batch_size=batch_size,
+                retry=retry,
+            )
+
     packed = [(fn, args) for args in items]
     return parallel_map(
         _unpack_call,
@@ -440,8 +524,30 @@ def parallel_iter(
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
 
     task_fn = fn
+    if executor == "process":
+        resolved = _resolve_process_target(fn)
+        if resolved is not None:
+            module_name, qualname = resolved
+            task_fn = functools.partial(
+                _call_resolved,
+                module_name=module_name,
+                qualname=qualname,
+            )
     if retry is not None:
         task_fn = functools.partial(_run_with_retry, fn, retry=retry)
+        if executor == "process":
+            resolved = _resolve_process_target(fn)
+            if resolved is not None:
+                module_name, qualname = resolved
+                task_fn = functools.partial(
+                    _run_with_retry,
+                    functools.partial(
+                        _call_resolved,
+                        module_name=module_name,
+                        qualname=qualname,
+                    ),
+                    retry=retry,
+                )
 
     pool_cls = ThreadPoolExecutor if executor == "thread" else ProcessPoolExecutor
     bucket = _TokenBucket(rate_limit) if rate_limit else None

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -11,13 +11,15 @@ import importlib
 import random
 import threading
 import time
-from concurrent.futures import (Future, ProcessPoolExecutor,
-                                ThreadPoolExecutor, as_completed)
+from collections.abc import Callable, Iterable, Iterator
+from concurrent.futures import (
+    Future,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    as_completed,
+)
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Iterable, Iterator, Literal, TypeVar
-
-T = TypeVar("T")
-R = TypeVar("R")
+from typing import Any, Literal
 
 ExecutorType = Literal["thread", "process"]
 
@@ -170,7 +172,7 @@ def _resolve_process_target(
     return (module_name, qualname)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _load_process_target(module_name: str, qualname: str) -> Callable[..., Any]:
     """Import and resolve a callable by module and qualname."""
     target: Any = importlib.import_module(module_name)
@@ -198,7 +200,7 @@ def _call_resolved_args(
 # ---------------------------------------------------------------------------
 
 
-class ParallelResult(Generic[R]):
+class ParallelResult[R]:
     """Results from parallel execution.
 
     Behaves like a ``list[R]`` when every task succeeded.
@@ -294,7 +296,7 @@ def _run_with_retry(fn: Callable[..., Any], item: Any, retry: Retry) -> Any:
     raise last_exc  # type: ignore[misc]
 
 
-def parallel_map(
+def parallel_map[R](
     fn: Callable[..., R],
     items: Iterable[Any],
     *,
@@ -336,9 +338,10 @@ def parallel_map(
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')
     if task_timeout is not None:
         raise NotImplementedError(
-            "task_timeout is not supported in sync parallel_map — Python threads "
-            "cannot be cancelled mid-execution. Use timeout= for a total wall-clock "
-            "limit, or put timeouts inside your function (e.g. requests.get(url, timeout=5)). "
+            "task_timeout is not supported in sync parallel_map — Python "
+            "threads cannot be cancelled mid-execution. Use timeout= for a "
+            "total wall-clock limit, or put timeouts inside your function "
+            "(e.g. requests.get(url, timeout=5)). "
             "For per-task timeouts, use async_parallel_map with task_timeout=."
         )
 
@@ -436,7 +439,7 @@ def _unpack_call(fn_and_args: tuple[Callable[..., Any], tuple[Any, ...]]) -> Any
     return fn(*args)
 
 
-def parallel_starmap(
+def parallel_starmap[R](
     fn: Callable[..., R],
     items: Iterable[tuple[Any, ...]],
     *,
@@ -489,7 +492,7 @@ def parallel_starmap(
     )
 
 
-def parallel_iter(
+def parallel_iter[R](
     fn: Callable[..., R],
     items: Iterable[Any],
     *,
@@ -728,7 +731,7 @@ class _ParallelFunc:
         )
 
 
-def parallel(
+def parallel[R](
     fn: Callable[..., R] | None = None,
     *,
     workers: int | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,28 +41,19 @@ testpaths = [
     "tests",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+# E/W=pycodestyle, F=pyflakes, I=isort, UP=pyupgrade, B=bugbear, SIM=simplify
+
+[tool.ruff.lint.isort]
+known-first-party = ["pyarallel"]
 
 [dependency-groups]
 dev = [
-    "black>=24.10.0",
-    "isort>=5.13.2",
+    "ruff>=0.15.0",
     "mkdocs-git-revision-date-plugin>=0.3.2",
     "mkdocs-material[imaging]>=9.5.50",
     "mkdocs-minify-plugin>=0.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ packages = ["pyarallel"]
 [tool.pytest.ini_options]
 addopts = "-ra -q"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = [
     "tests",
 ]

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -5,17 +5,23 @@ Run with: uv run smoke_test.py
 """
 
 import asyncio
-import json
 import os
 import sys
 import tempfile
+import threading
 import time
 
 # Ensure we're importing the local version
 sys.path.insert(0, os.path.dirname(__file__))
 
-from pyarallel import (ParallelResult, RateLimit, Retry, async_parallel,
-                       async_parallel_map, parallel, parallel_map)
+from pyarallel import (
+    RateLimit,
+    Retry,
+    async_parallel,
+    async_parallel_map,
+    parallel,
+    parallel_map,
+)
 
 PASS = 0
 FAIL = 0
@@ -58,8 +64,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
 # 2. Batch processing — verify memory control
 # ---------------------------------------------------------------------------
 print("\n--- Sync: Batch processing ---")
-
-import threading
 
 peak_concurrent = 0
 current_concurrent = 0
@@ -122,7 +126,7 @@ elapsed = time.monotonic() - start
 check(
     f"rate limit timing ({elapsed:.2f}s)",
     elapsed >= 0.35,
-    f"expected >= 0.35s for 10 items at 20/sec",
+    "expected >= 0.35s for 10 items at 20/sec",
 )
 
 # ---------------------------------------------------------------------------
@@ -251,7 +255,7 @@ asyncio.run(run_async_tests())
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-print(f"\n{'='*50}")
+print(f"\n{'=' * 50}")
 print(f"  {PASS} passed, {FAIL} failed")
-print(f"{'='*50}")
+print(f"{'=' * 50}")
 sys.exit(1 if FAIL > 0 else 0)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -3,8 +3,6 @@
 import threading
 import time
 
-import pytest
-
 from pyarallel import RateLimit, parallel_map
 
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -3,6 +3,16 @@
 from pyarallel import parallel, parallel_map
 
 
+@parallel(workers=2, executor="process")
+def _process_double(x):
+    return x * 2
+
+
+@parallel(workers=2, executor="process")
+def _process_add(a, b):
+    return a + b
+
+
 class TestBasicDecorator:
     def test_single_call_returns_plain_value(self):
         @parallel(workers=2)
@@ -58,6 +68,19 @@ class TestDecoratorOverrides:
         identity.map(range(5), rate_limit=10)
         elapsed = time.monotonic() - start
         assert elapsed >= 0.3
+
+    def test_process_executor_map(self):
+        results = _process_double.map([1, 2, 3])
+        assert list(results) == [2, 4, 6]
+
+    def test_process_executor_starmap(self):
+        results = _process_add.starmap([(1, 2), (3, 4)])
+        assert list(results) == [3, 7]
+
+    def test_process_executor_stream(self):
+        results = list(_process_double.stream([1, 2, 3]))
+        results.sort()
+        assert results == [(0, 2), (1, 4), (2, 6)]
 
 
 class TestMethodSupport:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -2,9 +2,7 @@
 
 import time
 
-import pytest
-
-from pyarallel import RateLimit, parallel_map
+from pyarallel import parallel_map
 from pyarallel.core import Retry
 
 
@@ -66,7 +64,7 @@ class TestRetryBehavior:
             assert isinstance(exc, RuntimeError)
 
     def test_retry_count_matches_attempts(self):
-        """Verify the function is called exactly `attempts` times on persistent failure."""
+        """Verify function is called exactly `attempts` times on failure."""
         call_count = {}
 
         def counter(x):
@@ -162,8 +160,8 @@ class TestJitter:
         for _ in range(2):
             timestamps = []
 
-            def always_fail(x):
-                timestamps.append(time.monotonic())
+            def always_fail(x, _ts=timestamps):
+                _ts.append(time.monotonic())
                 raise ValueError("fail")
 
             parallel_map(

--- a/tests/test_starmap.py
+++ b/tests/test_starmap.py
@@ -2,9 +2,7 @@
 
 import time
 
-import pytest
-
-from pyarallel import RateLimit, parallel_map
+from pyarallel import RateLimit
 from pyarallel.core import Retry
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,9 +1,6 @@
 """Tests for parallel_iter / .stream() — streaming results, constant memory."""
 
-import threading
 import time
-
-import pytest
 
 from pyarallel import RateLimit
 from pyarallel.core import Retry
@@ -42,7 +39,7 @@ class TestParallelIterStreaming:
         from pyarallel import parallel_iter
 
         yielded_count = 0
-        for index, value in parallel_iter(
+        for _index, _value in parallel_iter(
             lambda x: x * 2,
             range(20),
             workers=2,

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-03-14T08:35:34.951211Z"
+exclude-newer = "2026-03-14T09:38:12.003914Z"
 exclude-newer-span = "P30D"
 
 [options.exclude-newer-package]
@@ -21,30 +21,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/74/f1bc80f23eeba13393b7222b11d95ca3af2c1e28edca18af487137eefed9/babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316", size = 9348104, upload-time = "2024-08-08T14:25:45.459Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/20/bc79bc575ba2e2a7f70e8a1155618bb1301eaa5132a8271373a6903f73f8/babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b", size = 9587599, upload-time = "2024-08-08T14:25:42.686Z" },
-]
-
-[[package]]
-name = "black"
-version = "24.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload-time = "2024-10-07T19:20:50.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256, upload-time = "2024-10-07T19:27:53.355Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534, upload-time = "2024-10-07T19:26:44.953Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892, upload-time = "2024-10-07T19:24:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796, upload-time = "2024-10-07T19:25:06.239Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986, upload-time = "2024-10-07T19:28:50.684Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085, upload-time = "2024-10-07T19:28:12.093Z" },
-    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928, upload-time = "2024-10-07T19:24:15.233Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875, upload-time = "2024-10-07T19:24:42.762Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898, upload-time = "2024-10-07T19:20:48.317Z" },
 ]
 
 [[package]]
@@ -370,15 +346,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
-]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
 ]
 
 [[package]]
@@ -849,9 +816,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "build" },
-    { name = "isort" },
     { name = "mkdocs-git-revision-date-plugin" },
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocs-minify-plugin" },
@@ -859,6 +824,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
     { name = "twine" },
 ]
 
@@ -866,9 +832,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.10.0" },
     { name = "build", specifier = ">=1.0.0" },
-    { name = "isort", specifier = ">=5.13.2" },
     { name = "mkdocs-git-revision-date-plugin", specifier = ">=0.3.2" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.5.50" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
@@ -876,6 +840,7 @@ dev = [
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = ">=0.15.0" },
     { name = "twine", specifier = ">=6.0.0" },
 ]
 
@@ -1105,6 +1070,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- fix `@parallel(..., executor="process")` so decorated top-level functions work with `.map()`, `.starmap()`, and `.stream()`
- refresh the example suite to match the current public API and make the scripts runnable again
- set `asyncio_default_fixture_loop_scope` explicitly to remove the pytest-asyncio deprecation warning

## Validation
- `uv run python -m pytest tests/ -q`
- `uv run python examples/01_basic_usage.py`
- `uv run python examples/02_api_calls_with_rate_limiting.py`
- `uv run python examples/03_cpu_bound_processing.py`
- `uv run python examples/04_batch_processing.py`
- `uv run python examples/05_configuration.py`