### PR TITLE
Fix API consistency, lazy batching, and modernize tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Pyarallel is a Python library for parallel execution, designed to make concurrent programming easy and efficient. It uses a decorator-based API and supports both thread-based (for I/O-bound tasks) and process-based (for CPU-bound tasks) parallelism. Key features include rate limiting, batch processing, and a flexible configuration system.
+Pyarallel is a Python library for explicit parallel execution. It provides
+sync and async map/stream helpers plus decorator-based APIs. It supports
+thread-based execution for I/O-bound work and process-based execution for
+CPU-bound work. Core features include rate limiting, batch processing, retry,
+and structured result handling.
 
 ## Code Architecture
 
-The core of Pyarallel revolves around the `@parallel` decorator (`pyarallel/core.py`) which wraps functions to enable parallel execution.
+The core sync API lives in `pyarallel/core.py` and the async API lives in
+`pyarallel/aio.py`.
 
-Configuration is managed by the `ConfigManager` (`pyarallel/config_manager.py`), a singleton class that handles global settings. It supports updates via Python code and environment variables. Configuration settings are structured into categories like `execution`, `rate_limiting`, `error_handling`, and `monitoring`. Environment variables use the `PYARALLEL_` prefix (e.g., `PYARALLEL_MAX_WORKERS`).
+Important public types and functions:
+- `parallel_map`, `parallel_starmap`, `parallel_iter`
+- `async_parallel_map`, `async_parallel_starmap`, `async_parallel_iter`
+- `@parallel` and `@async_parallel`
+- `ParallelResult`, `ItemResult`, `RateLimit`, and `Retry`
 
-Rate limiting logic is implemented in `pyarallel/core.py` and utilizes a `TokenBucket` class.
-
-The library supports various callable types, including regular functions, instance methods, class methods, and static methods.
+Rate limiting is implemented with local token-bucket helpers in the sync and
+async modules. The library supports regular functions plus instance methods via
+the descriptor protocol used by the decorator wrappers.
 
 ## Common Commands
 
@@ -25,7 +34,7 @@ git clone https://github.com/oneryalcin/pyarallel.git
 cd pyarallel
 
 # Install development dependencies
-pip install -e ".[dev]"
+uv sync --group dev
 ```
 
 ### Running Tests
@@ -37,11 +46,11 @@ pytest tests/ -v
 ```
 To run a single test file:
 ```bash
-pytest tests/test_pyarallel.py -v
+pytest tests/test_parallel_map.py -v
 ```
 To run a specific test case:
 ```bash
-pytest tests/test_pyarallel.py::test_basic_parallel_processing -v
+pytest tests/test_parallel_map.py::TestParallelMapBasic::test_basic_parallel_map -v
 ```
 
 ### Formatting Code
@@ -90,7 +99,7 @@ make docs-deploy
 
 ## Development Guidelines
 
-- Follow the coding style enforced by Black (line length 88 characters).
+- Follow the coding style enforced by Ruff formatting and linting (line length 88 characters).
 - Use type hints for function arguments and return values.
 - Write docstrings for all public functions and classes.
 - Add tests for new code and ensure the test suite passes (`make test`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,16 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 
 ## Use a Consistent Coding Style
 
-* Use [Black](https://github.com/psf/black) for Python code formatting
-* Keep line length to 88 characters (Black default)
+* Use `uv run ruff format .` for formatting
+* Use `uv run ruff check .` for linting and import ordering
+* Keep line length to 88 characters
 * Use type hints for function arguments and return values
 * Write docstrings for all public functions and classes
 
 ## Running Tests
 
 ```bash
-pytest tests/
+uv run python -m pytest tests/ -q
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ For large-scale processing where results shouldn't accumulate:
 ```python
 from pyarallel import parallel_iter
 
-for index, value in parallel_iter(process, ten_million_items, batch_size=1000):
-    db.save(value)  # yielded and discarded — no accumulation
+for item in parallel_iter(process, ten_million_items, batch_size=1000):
+    if item.ok:
+        db.save(item.value)  # yielded and discarded — no accumulation
+    else:
+        log_error(item.index, item.error)
 ```
 
 ### Async Support
@@ -145,7 +148,7 @@ s.fetch.stream(urls, batch_size=100) # streaming
 |---|---|---|---|
 | `parallel_map(fn, items)` | `.map(items)` | `ParallelResult` | Results fit in memory |
 | `parallel_starmap(fn, items)` | `.starmap(items)` | `ParallelResult` | Multi-arg, fits in memory |
-| `parallel_iter(fn, items)` | `.stream(items)` | `Iterator[(int, T)]` | Streaming, constant memory |
+| `parallel_iter(fn, items)` | `.stream(items)` | `Iterator[ItemResult[T]]` | Streaming, constant memory |
 
 Async variants: `async_parallel_map`, `async_parallel_starmap`, `async_parallel_iter`
 

--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -17,7 +17,7 @@ results = await async_parallel_map(
     rate_limit=None,                 # RateLimit or ops/second
     task_timeout=None,                    # Per-task timeout in seconds
     on_progress=None,                # callback(completed, total)
-    batch_size=None,                 # Process in chunks to control memory
+    batch_size=None,                 # Lazy batch consumption for unsized iterables
     retry=None,                      # Retry(attempts=3, backoff=1.0)
 )
 ```
@@ -33,8 +33,8 @@ results = await async_parallel_map(
 | `concurrency` | `int` | `4` | Maximum concurrent tasks |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting |
 | `task_timeout` | `float \| None` | `None` | **Per-task** timeout in seconds |
-| `on_progress` | `Callable[[int, int], None] \| None` | `None` | Progress callback |
-| `batch_size` | `int \| None` | `None` | Process items in chunks (controls memory) |
+| `on_progress` | `Callable[[int, int], None] \| None` | `None` | Progress callback. For unsized iterables with batching, `total` is items seen so far |
+| `batch_size` | `int \| None` | `None` | Process items in chunks. With unsized iterables, input is consumed lazily one batch at a time |
 | `retry` | `Retry \| None` | `None` | Per-item retry with backoff |
 
 ### Why `concurrency` instead of `workers`?
@@ -68,6 +68,16 @@ results = await async_parallel_map(
     task_timeout=5.0,
 )
 ```
+
+### Notes on Progress and Unsized Iterables
+
+When `items` has a known length, `on_progress(done, total)` reports the final
+total.
+
+When `items` is unsized (for example a generator) and `batch_size` is set,
+Pyarallel keeps input consumption lazy instead of materializing the full input
+up front. In that mode, `total` is the number of items discovered so far, not a
+guaranteed final total.
 
 ---
 

--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -41,7 +41,9 @@ results = await async_parallel_map(
 
 The sync API uses `workers` because it sizes a thread/process **pool** — you're creating real OS threads or processes. The async API uses `concurrency` because there's no pool — everything runs on one event loop, and `concurrency` controls how many tasks are allowed to run at the same time via a semaphore.
 
-Calling both `workers` would be misleading (async has no workers). Calling both `concurrency` would be wrong for sync (you're literally setting `ThreadPoolExecutor(max_workers=N)`). The names match what each actually controls.
+Calling both `workers` would be misleading because async execution has no worker pool. Calling both `concurrency` would be wrong for sync because the implementation really is sizing `ThreadPoolExecutor(max_workers=N)` or `ProcessPoolExecutor(max_workers=N)`. The names match what each API actually controls.
+
+Pre-v1, Pyarallel keeps these names intentionally different. If you're moving from sync to async, translate `workers=` to `concurrency=` rather than expecting them to be interchangeable.
 
 ### Other Differences from Sync
 

--- a/docs/api-reference/async.md
+++ b/docs/api-reference/async.md
@@ -100,13 +100,16 @@ Takes the same options as `async_parallel_map`. Also available as `.starmap()` o
 
 ## `async_parallel_iter`
 
-Async streaming — yields `(index, result_or_exception)` in completion order. Constant memory.
+Async streaming — yields `ItemResult` in completion order. Constant memory.
 
 ```python
 from pyarallel import async_parallel_iter
 
-async for index, value in async_parallel_iter(fetch, urls, concurrency=10):
-    await db.save(value)
+async for item in async_parallel_iter(fetch, urls, concurrency=10):
+    if item.ok:
+        await db.save(item.value)
+    else:
+        log_error(item.index, item.error)
 ```
 
 Also available as `.stream()` on `@async_parallel` decorated functions:
@@ -115,8 +118,11 @@ Also available as `.stream()` on `@async_parallel` decorated functions:
 @async_parallel(concurrency=10)
 async def fetch(url): ...
 
-async for index, value in fetch.stream(urls, batch_size=1000):
-    await db.save(value)
+async for item in fetch.stream(urls, batch_size=1000):
+    if item.ok:
+        await db.save(item.value)
+    else:
+        log_error(item.index, item.error)
 ```
 
 ---

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -16,7 +16,7 @@ results = parallel_map(
     rate_limit=None,                 # RateLimit object or ops/second (float)
     timeout=None,                    # Total timeout in seconds
     on_progress=None,                # callback(completed, total)
-    batch_size=None,                 # Process in chunks to control memory
+    batch_size=None,                 # Lazy batch consumption for unsized iterables
     retry=None,                      # Retry(attempts=3, backoff=1.0)
 )
 ```
@@ -33,8 +33,8 @@ results = parallel_map(
 | `executor` | `"thread" \| "process"` | `"thread"` | Thread pool or process pool |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting (float = ops/second) |
 | `timeout` | `float \| None` | `None` | Total wall-clock timeout in seconds |
-| `on_progress` | `Callable[[int, int], None] \| None` | `None` | Progress callback `(completed, total)` |
-| `batch_size` | `int \| None` | `None` | Process items in chunks of this size (controls memory) |
+| `on_progress` | `Callable[[int, int], None] \| None` | `None` | Progress callback `(completed, total)`. For unsized iterables with batching, `total` is items seen so far |
+| `batch_size` | `int \| None` | `None` | Process items in chunks of this size. With unsized iterables, input is consumed lazily one batch at a time |
 | `retry` | `Retry \| None` | `None` | Per-item retry with backoff |
 
 ### Examples
@@ -53,12 +53,22 @@ results = parallel_map(fetch, urls, rate_limit=10)  # 10 per second
 results = parallel_map(fetch, urls, timeout=60.0,
                        on_progress=lambda d, t: print(f"{d}/{t}"))
 
-# Batched — controls memory for large datasets
+# Batched — keeps unsized iterables lazy one batch at a time
 results = parallel_map(process, million_items, workers=8, batch_size=500)
 
 # With retry — flaky network calls
 results = parallel_map(fetch, urls, workers=10, retry=Retry(attempts=3, backoff=1.0))
 ```
+
+### Notes on Progress and Unsized Iterables
+
+When `items` has a known length, `on_progress(done, total)` reports the final
+total.
+
+When `items` is unsized (for example a generator) and `batch_size` is set,
+Pyarallel keeps input consumption lazy instead of materializing the full input
+up front. In that mode, `total` is the number of items discovered so far, not a
+guaranteed final total.
 
 ---
 

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -141,7 +141,7 @@ Like `parallel_map` but unpacks each item as `fn(*args)` — for functions that 
 ```python
 from pyarallel import parallel_starmap
 
-results = parallel_starmap(fn, [(arg1, arg2), (arg3, arg4), ...], workers=4)
+results = parallel_starmap(fn, [(arg1, arg2), (arg3, arg4), ...])
 ```
 
 Takes the same options as `parallel_map` (workers, executor, rate_limit, timeout, batch_size, retry).
@@ -198,7 +198,7 @@ Same as `parallel_map` except no `timeout` or `on_progress` (results stream as t
 |---|---|---|---|
 | `fn` | `Callable` | required | Function to apply to each item |
 | `items` | `Iterable` | required | Any iterable |
-| `workers` | `int` | `4` | Number of parallel workers |
+| `workers` | `int \| None` | `None` | Number of parallel workers (stdlib default when `None`) |
 | `executor` | `"thread" \| "process"` | `"thread"` | Thread pool or process pool |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting |
 | `batch_size` | `int \| None` | `None` | Process in chunks (controls memory) |

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -172,16 +172,17 @@ add.starmap([(1, 2), (3, 4)])  # ParallelResult([3, 7])
 
 ## `parallel_iter`
 
-Streaming version of `parallel_map` — yields `(index, result_or_exception)` in completion order. Results are **not accumulated in memory**.
+Streaming version of `parallel_map` — yields `ItemResult` in completion order.
+Results are **not accumulated in memory**.
 
 ```python
 from pyarallel import parallel_iter
 
-for index, value in parallel_iter(fn, items, workers=4, batch_size=1000):
-    if isinstance(value, Exception):
-        log_error(index, value)
+for item in parallel_iter(fn, items, workers=4, batch_size=1000):
+    if item.ok:
+        db.save(item.value)
     else:
-        db.save(value)
+        log_error(item.index, item.error)
 ```
 
 ### When to Use
@@ -205,7 +206,8 @@ Same as `parallel_map` except no `timeout` or `on_progress` (results stream as t
 
 ### Yields
 
-`(int, T | Exception)` — index and result in **completion order** (not input order). Failed tasks yield the exception as the value.
+`ItemResult[T]` — each item includes `.index`, `.ok`, `.value`, and `.error`.
+Results arrive in **completion order** (not input order).
 
 Also available as `.stream()` on `@parallel` decorated functions:
 
@@ -213,8 +215,11 @@ Also available as `.stream()` on `@parallel` decorated functions:
 @parallel(workers=8)
 def process(item): ...
 
-for index, value in process.stream(huge_list, batch_size=1000):
-    db.save(value)
+for item in process.stream(huge_list, batch_size=1000):
+    if item.ok:
+        db.save(item.value)
+    else:
+        log_error(item.index, item.error)
 ```
 
 ---

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -11,7 +11,7 @@ results = parallel_map(
     fn,                              # Function to apply to each item
     items,                           # Any iterable
     *,
-    workers=4,                       # Number of parallel workers
+    workers=None,                    # Number of parallel workers
     executor="thread",               # "thread" or "process"
     rate_limit=None,                 # RateLimit object or ops/second (float)
     timeout=None,                    # Total timeout in seconds
@@ -29,7 +29,7 @@ results = parallel_map(
 |---|---|---|---|
 | `fn` | `Callable` | required | Function to apply to each item |
 | `items` | `Iterable` | required | Any iterable (list, generator, range, set, ...) |
-| `workers` | `int` | `4` | Number of parallel workers |
+| `workers` | `int \| None` | `None` | Number of parallel workers. `None` lets the executor choose |
 | `executor` | `"thread" \| "process"` | `"thread"` | Thread pool or process pool |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Rate limiting (float = ops/second) |
 | `timeout` | `float \| None` | `None` | Total wall-clock timeout in seconds |
@@ -85,7 +85,7 @@ def fn(item): ...
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `workers` | `int` | `4` | Default worker count for `.map()` |
+| `workers` | `int \| None` | `None` | Default worker count for `.map()` |
 | `executor` | `"thread" \| "process"` | `"thread"` | Default executor type |
 | `rate_limit` | `RateLimit \| float \| None` | `None` | Default rate limiting |
 
@@ -224,6 +224,36 @@ for item in process.stream(huge_list, batch_size=1000):
 
 ---
 
+## `ItemResult`
+
+Single streaming result item returned by `parallel_iter`, `async_parallel_iter`,
+and `.stream()`.
+
+### Properties
+
+| Member | Returns | Description |
+|---|---|---|
+| `.index` | `int` | Original input index |
+| `.ok` | `bool` | `True` when this item succeeded |
+| `.value` | `T \| None` | Result value for successful items. May legitimately be `None` |
+| `.error` | `Exception \| None` | Exception for failed items |
+
+### Invariant
+
+Exactly one of `.value` or `.error` is set. Success and failure are explicit.
+
+### Example
+
+```python
+for item in parallel_iter(process, items, workers=4):
+    if item.ok:
+        handle(item.index, item.value)
+    else:
+        log(item.index, item.error)
+```
+
+---
+
 ## `ParallelResult`
 
 Container for parallel execution results. Behaves like a `list` when all tasks succeed. Provides structured access when some fail.
@@ -307,24 +337,41 @@ retry = Retry(attempts=3, backoff=1.0)
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `attempts` | `int` | `3` | Total attempts (1 = no retry, 3 = up to 2 retries) |
-| `backoff` | `float` | `0.0` | Seconds between retries, multiplied by attempt number |
+| `backoff` | `float` | `1.0` | Base delay for exponential backoff |
+| `max_delay` | `float` | `60.0` | Maximum sleep between retries |
+| `jitter` | `bool` | `True` | Randomize delays to avoid retry bursts |
+| `on` | `tuple[type[Exception], ...] \| None` | `None` | Retry only these exception types. `None` means retry all exceptions |
 
 ### Backoff Behavior
 
-With `backoff=1.0` and `attempts=3`:
+With `backoff=1.0`, `attempts=3`, and the default exponential logic:
 
 - Attempt 1: immediate
 - Attempt 2: sleep 1.0s, then retry
 - Attempt 3: sleep 2.0s, then retry
 
+The actual delay formula is `min(backoff * 2^attempt, max_delay)`, optionally
+multiplied by jitter.
+
 ### Examples
 
 ```python
-# Basic retry — 3 attempts, no wait
+# Basic retry — 3 attempts, exponential backoff starting at 1s
 results = parallel_map(fetch, urls, retry=Retry())
 
-# Retry with exponential-ish backoff
-results = parallel_map(fetch, urls, retry=Retry(attempts=5, backoff=0.5))
+# Retry only transient network failures
+results = parallel_map(
+    fetch,
+    urls,
+    retry=Retry(on=(ConnectionError, TimeoutError)),
+)
+
+# Retry with custom caps and deterministic delays
+results = parallel_map(
+    fetch,
+    urls,
+    retry=Retry(attempts=5, backoff=0.5, max_delay=5.0, jitter=False),
+)
 
 # Retry + rate limit + batch — the full production stack
 results = parallel_map(

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -40,15 +40,16 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 
 ## Use a Consistent Coding Style
 
-* Use [Black](https://github.com/psf/black) for Python code formatting
-* Keep line length to 88 characters (Black default)
+* Use `uv run ruff format .` for formatting
+* Use `uv run ruff check .` for linting and import ordering
+* Keep line length to 88 characters
 * Use type hints for function arguments and return values
 * Write docstrings for all public functions and classes
 
 ## Running Tests
 
 ```bash
-pytest tests/
+uv run python -m pytest tests/ -q
 ```
 
 ## License

--- a/docs/development/devx-principles.md
+++ b/docs/development/devx-principles.md
@@ -1,0 +1,49 @@
+# DevX Principles
+
+These are the product and API design principles for Pyarallel. Use them when
+adding features, changing names, or deciding whether a convenience API is worth
+the long-term cost.
+
+## 1. Keep the Surface Small
+
+Pyarallel should feel like a few sharp tools, not a framework. New features
+must justify their cost in API surface, docs, and maintenance.
+
+## 2. Prefer Explicit Semantics
+
+Different concepts should use different names. Sync pool sizing is not the same
+thing as async coroutine concurrency. Convenience should not come from hiding
+real semantic differences.
+
+## 3. Optimize for Strong Typing
+
+Return types should make success and failure explicit. Good autocomplete, clear
+editor errors, and predictable type checking are part of the product.
+
+## 4. Preserve Native Call Feel
+
+Decorators and wrappers should keep normal call signatures and return values
+whenever possible. Parallel behavior should feel additive, not magical.
+
+## 5. Document Tradeoffs Honestly
+
+Do not oversell behavior. If batching is lazy only with `batch_size`, say that.
+If progress totals are provisional for unsized iterables, say that. Trust comes
+from accuracy.
+
+## 6. Prefer One Honest Model Over Two Convenient Ones
+
+If sync and async APIs need different terms, keep them different. If streaming
+needs a typed result object, use one instead of mixing values and exceptions in
+the same channel.
+
+## 7. Deprecate Deliberately
+
+When an API is wrong or confusing, prefer a clean replacement path over keeping
+compatibility forever. Pre-v1 is the time to fix conceptual mistakes.
+
+## 8. Avoid Premature Abstraction
+
+Do not split code or add layers just because a review suggests it. Extract only
+when behavior is truly duplicated or when a boundary materially improves
+correctness, maintainability, or clarity.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,5 +1,7 @@
 # Roadmap
 
+This roadmap should be read together with the [DevX Principles](devx-principles.md).
+
 ## Current (v0.3.0)
 
 - `parallel_map()` / `.map()` — explicit parallel execution over iterables

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -99,6 +99,9 @@ Control memory for large datasets — process in chunks:
 results = parallel_map(process, huge_list, workers=8, batch_size=500)
 ```
 
+For unsized iterables such as generators, `batch_size` also keeps input
+consumption lazy one batch at a time.
+
 ## Error Handling
 
 Errors are never silently lost. `ParallelResult` gives you structured access:

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -13,6 +13,11 @@ def my_progress(done, total):
 results = parallel_map(process, items, workers=8, on_progress=my_progress)
 ```
 
+If `items` has a known length, `total` is the final input size. If `items` is
+an unsized iterable (for example a generator) and you also set `batch_size`,
+Pyarallel keeps input consumption lazy; in that mode `total` is the number of
+items discovered so far.
+
 Works with both `parallel_map` and `.map()`:
 
 ```python
@@ -154,6 +159,9 @@ Control memory for large datasets by processing in chunks:
 # Submit 500 items at a time instead of 500,000 at once
 results = parallel_map(process, huge_list, workers=8, batch_size=500)
 ```
+
+With `batch_size` set, unsized iterables are consumed lazily one batch at a
+time instead of being materialized up front.
 
 Errors in one batch don't prevent subsequent batches from running.
 

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -194,22 +194,26 @@ For large-scale processing where results shouldn't accumulate in memory, use `pa
 from pyarallel import parallel_iter
 
 # Process 10M items — only one batch of results in memory at a time
-for index, value in parallel_iter(process, ten_million_items,
-                                  workers=8, batch_size=1000):
-    if isinstance(value, Exception):
-        log_error(index, value)
+for item in parallel_iter(process, ten_million_items,
+                          workers=8, batch_size=1000):
+    if item.ok:
+        db.save(item.value)
     else:
-        db.save(value)
+        log_error(item.index, item.error)
 
 # Or with the decorator
 @parallel(workers=8)
 def process(item): ...
 
-for index, value in process.stream(huge_list, batch_size=1000):
-    db.save(value)
+for item in process.stream(huge_list, batch_size=1000):
+    if item.ok:
+        db.save(item.value)
+    else:
+        log_error(item.index, item.error)
 ```
 
-Results arrive in **completion order** (fastest tasks first), not input order. Each `(index, value)` tuple includes the original index so you can match results to inputs.
+Results arrive in **completion order** (fastest tasks first), not input order.
+Each `ItemResult` includes the original `.index` so you can match results to inputs.
 
 **When to use which:**
 

--- a/docs/user-guide/best-practices.md
+++ b/docs/user-guide/best-practices.md
@@ -32,8 +32,7 @@ results = parallel_map(compute, data, workers=4, executor="process")
 
 ### Worker Count
 
-`parallel_map()` and `@parallel(...).map()` default to `workers=None`, which lets
-the stdlib pick a sensible number automatically:
+By default, `workers=None` — the stdlib picks a sensible number automatically:
 
 - **Threads**: `min(32, cpu_count + 4)` — Python's `ThreadPoolExecutor` default
 - **Processes**: `cpu_count()` — Python's `ProcessPoolExecutor` default
@@ -50,10 +49,6 @@ results = parallel_map(fetch, urls, workers=100)       # high concurrency for fa
 results = parallel_map(crunch, data, executor="process",
                        workers=multiprocessing.cpu_count() - 1)  # leave a core free
 ```
-
-`parallel_starmap()` and `parallel_iter()` currently default to `workers=4`.
-If you want consistent worker counts across all sync APIs, pass `workers=...`
-explicitly instead of relying on defaults.
 
 ## Rate Limiting
 

--- a/docs/user-guide/best-practices.md
+++ b/docs/user-guide/best-practices.md
@@ -32,7 +32,8 @@ results = parallel_map(compute, data, workers=4, executor="process")
 
 ### Worker Count
 
-By default, `workers=None` — the stdlib picks a sensible number automatically:
+`parallel_map()` and `@parallel(...).map()` default to `workers=None`, which lets
+the stdlib pick a sensible number automatically:
 
 - **Threads**: `min(32, cpu_count + 4)` — Python's `ThreadPoolExecutor` default
 - **Processes**: `cpu_count()` — Python's `ProcessPoolExecutor` default
@@ -49,6 +50,10 @@ results = parallel_map(fetch, urls, workers=100)       # high concurrency for fa
 results = parallel_map(crunch, data, executor="process",
                        workers=multiprocessing.cpu_count() - 1)  # leave a core free
 ```
+
+`parallel_starmap()` and `parallel_iter()` currently default to `workers=4`.
+If you want consistent worker counts across all sync APIs, pass `workers=...`
+explicitly instead of relying on defaults.
 
 ## Rate Limiting
 

--- a/docs/user-guide/best-practices.md
+++ b/docs/user-guide/best-practices.md
@@ -81,7 +81,10 @@ For large datasets, use `batch_size` to limit how many futures exist at once:
 results = parallel_map(process, huge_list, workers=8, batch_size=1000)
 ```
 
-Without `batch_size`, all items are submitted at once. On memory-constrained environments (K8s pods, Lambda), this prevents OOM kills.
+Without `batch_size`, all items are submitted at once. With `batch_size` set,
+unsized iterables are consumed lazily one batch at a time. On
+memory-constrained environments (K8s pods, Lambda), this helps prevent OOM
+kills.
 
 ## Error Handling Patterns
 
@@ -172,4 +175,5 @@ def test_decorated_function():
 2. **Use rate limiting for external APIs** — protects you and the service
 3. **Prefer threads for I/O** — processes have serialization overhead
 4. **Check `result.ok` before iterating** — avoids surprise `ExceptionGroup` raises
-5. **Use `on_progress` for long jobs** — visibility into what's happening
+5. **Use `on_progress` for long jobs** — for unsized iterables with batching,
+   `total` is items seen so far, not the final size

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - Rate Limiting: api-reference/rate-limiting.md
   - Development:
     - Contributing: development/CONTRIBUTING.md
+    - DevX Principles: development/devx-principles.md
     - Roadmap: development/roadmap.md
 
 markdown_extensions:

--- a/pyarallel/__init__.py
+++ b/pyarallel/__init__.py
@@ -7,6 +7,7 @@ from .aio import (
     async_parallel_starmap,
 )
 from .core import (
+    ItemResult,
     ParallelResult,
     RateLimit,
     Retry,
@@ -19,6 +20,7 @@ from .core import (
 __version__ = "0.3.0"
 __all__ = [
     "ParallelResult",
+    "ItemResult",
     "RateLimit",
     "Retry",
     "parallel",

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -20,6 +20,7 @@ from .core import (
     Retry,
     _coerce_rate_limit,
     _Failure,
+    _iter_batches,
     _make_chunks,
     _merge_opts,
     _plan_collected_map,
@@ -207,10 +208,17 @@ async def async_parallel_iter(
     if concurrency < 1:
         raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
-    items_list = list(items)
-    n = len(items_list)
-    if n == 0:
-        return
+    if batch_size is None:
+        items_list = list(items)
+        n = len(items_list)
+        if n == 0:
+            return
+        batches: Iterable[list[tuple[int, Any]]] = (
+            [*enumerate(items_list[chunk.start : chunk.stop], chunk.start)]
+            for chunk in _make_chunks(n, batch_size)
+        )
+    else:
+        batches = _iter_batches(items, batch_size)
 
     semaphore = asyncio.Semaphore(concurrency)
     limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
@@ -235,10 +243,10 @@ async def async_parallel_iter(
 
     active_tasks: list[asyncio.Task[None]] = []
     try:
-        for chunk in _make_chunks(n, batch_size):
+        for batch in batches:
             chunk_tasks = []
-            for i in chunk:
-                t = asyncio.create_task(_run(i, items_list[i]))
+            for i, item in batch:
+                t = asyncio.create_task(_run(i, item))
                 chunk_tasks.append(t)
                 active_tasks.append(t)
 

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from .core import (
     _PENDING,
+    ItemResult,
     ParallelResult,
     RateLimit,
     Retry,
@@ -244,9 +245,9 @@ async def async_parallel_iter(
     task_timeout: float | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
-) -> AsyncIterator[tuple[int, Any]]:
-    """Execute async *fn* over *items*, yielding ``(index, result)``
-    in completion order. Constant memory — results are not accumulated.
+) -> AsyncIterator[ItemResult[Any]]:
+    """Execute async *fn* over *items*, yielding ``ItemResult`` in
+    completion order. Constant memory — results are not accumulated.
     """
     if isinstance(rate_limit, (int, float)):
         rate_limit = RateLimit(rate_limit)
@@ -262,7 +263,7 @@ async def async_parallel_iter(
 
     semaphore = asyncio.Semaphore(concurrency)
     limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
-    queue: asyncio.Queue[tuple[int, Any] | None] = asyncio.Queue()
+    queue: asyncio.Queue[ItemResult[Any] | None] = asyncio.Queue()
 
     async def _run(i: int, item: Any) -> None:
         async with semaphore:
@@ -277,9 +278,9 @@ async def async_parallel_iter(
                     result = await asyncio.wait_for(fn(item), timeout=task_timeout)
                 else:
                     result = await fn(item)
-                await queue.put((i, result))
+                await queue.put(ItemResult(i, value=result))
             except Exception as exc:
-                await queue.put((i, exc))
+                await queue.put(ItemResult(i, error=exc))
 
     active_tasks: list[asyncio.Task[None]] = []
     try:
@@ -359,7 +360,7 @@ class _BoundAsyncParallel:
 
     async def stream(
         self, items: Iterable[Any], **kwargs: Any
-    ) -> AsyncIterator[tuple[int, Any]]:
+    ) -> AsyncIterator[ItemResult[Any]]:
         async for item in async_parallel_iter(
             self._fn, items, **_merge_opts(self._defaults, **kwargs)
         ):
@@ -425,7 +426,7 @@ class _AsyncParallelFunc:
 
     async def stream(
         self, items: Iterable[Any], **kwargs: Any
-    ) -> AsyncIterator[tuple[int, Any]]:
+    ) -> AsyncIterator[ItemResult[Any]]:
         async for item in async_parallel_iter(
             self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs)
         ):

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -103,7 +103,12 @@ async def async_parallel_map[R](
         rate_limit: ``RateLimit`` object, or ops-per-second as a number.
         task_timeout: Per-task timeout in seconds (each individual task).
         on_progress: ``callback(completed, total)`` after each task.
-        batch_size: Process items in chunks to control memory.
+            When ``items`` has no known length and ``batch_size`` is set,
+            ``total`` is the number of items seen so far rather than the
+            final input size.
+        batch_size: Process items in chunks. With ``batch_size`` set,
+            unsized iterables (for example generators) are consumed lazily
+            one batch at a time.
         retry: ``Retry`` object for per-item retry with backoff.
         workers: Alias for ``concurrency`` (for convenience when switching
             from sync API). Emits a warning; prefer ``concurrency``.

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -93,7 +93,6 @@ async def async_parallel_map[R](
     on_progress: Callable[[int, int], None] | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
-    workers: int | None = None,
 ) -> ParallelResult[R]:
     """Execute an async *fn* over *items* concurrently.
 
@@ -111,21 +110,10 @@ async def async_parallel_map[R](
             unsized iterables (for example generators) are consumed lazily
             one batch at a time.
         retry: ``Retry`` object for per-item retry with backoff.
-        workers: Alias for ``concurrency`` (for convenience when switching
-            from sync API). Emits a warning; prefer ``concurrency``.
 
     Returns:
         ``ParallelResult`` — same container as the sync API.
     """
-    if workers is not None:
-        import warnings
-
-        warnings.warn(
-            "workers= is not used in async_parallel_map — "
-            "did you mean concurrency=? Setting concurrency to the workers value.",
-            stacklevel=2,
-        )
-        concurrency = workers
     if isinstance(rate_limit, (int, float)):
         rate_limit = RateLimit(rate_limit)
     if batch_size is not None and batch_size < 1:

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -18,11 +18,12 @@ from .core import (
     ParallelResult,
     RateLimit,
     Retry,
+    _coerce_rate_limit,
     _Failure,
-    _iter_batches,
     _make_chunks,
     _merge_opts,
-    _total_if_known,
+    _plan_collected_map,
+    _progress_total,
 )
 
 # ---------------------------------------------------------------------------
@@ -114,54 +115,16 @@ async def async_parallel_map[R](
     Returns:
         ``ParallelResult`` — same container as the sync API.
     """
-    if isinstance(rate_limit, (int, float)):
-        rate_limit = RateLimit(rate_limit)
+    rate_limit = _coerce_rate_limit(rate_limit)
     if batch_size is not None and batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
     if concurrency < 1:
         raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
-    if batch_size is None:
-        items_list = list(items)
-        n = len(items_list)
-        if n == 0:
-            return ParallelResult([])
-
-        results: list[Any] = [_PENDING] * n
-        semaphore = asyncio.Semaphore(concurrency)
-        limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
-        completed = 0
-
-        async def _run(i: int, item: Any) -> None:
-            nonlocal completed
-            async with semaphore:
-                if limiter:
-                    await limiter.wait()
-                try:
-                    if retry is not None:
-                        result = await _async_run_with_retry(
-                            fn, item, retry, task_timeout=task_timeout
-                        )
-                    elif task_timeout is not None:
-                        result = await asyncio.wait_for(fn(item), timeout=task_timeout)
-                    else:
-                        result = await fn(item)
-                    results[i] = result
-                except Exception as exc:
-                    results[i] = _Failure(exc)
-                completed += 1
-                if on_progress:
-                    on_progress(completed, n)
-
-        for chunk in _make_chunks(n, batch_size):
-            async with asyncio.TaskGroup() as tg:
-                for i in chunk:
-                    tg.create_task(_run(i, items_list[i]))
-
-        return ParallelResult(results)
-
-    total = _total_if_known(items)
-    results: list[Any] = []
+    plan = _plan_collected_map(items, batch_size)
+    if plan.total == 0:
+        return ParallelResult([])
+    results = plan.results
     semaphore = asyncio.Semaphore(concurrency)
     limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
     completed = 0
@@ -185,10 +148,11 @@ async def async_parallel_map[R](
                 results[i] = _Failure(exc)
             completed += 1
             if on_progress:
-                on_progress(completed, total if total is not None else len(results))
+                on_progress(completed, _progress_total(plan.total, results))
 
-    for batch in _iter_batches(items, batch_size):
-        results.extend([_PENDING] * len(batch))
+    for batch in plan.batches:
+        if batch_size is not None:
+            results.extend([_PENDING] * len(batch))
         async with asyncio.TaskGroup() as tg:
             for i, item in batch:
                 tg.create_task(_run(i, item))
@@ -237,8 +201,7 @@ async def async_parallel_iter(
     """Execute async *fn* over *items*, yielding ``ItemResult`` in
     completion order. Constant memory — results are not accumulated.
     """
-    if isinstance(rate_limit, (int, float)):
-        rate_limit = RateLimit(rate_limit)
+    rate_limit = _coerce_rate_limit(rate_limit)
     if batch_size is not None and batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
     if concurrency < 1:

--- a/pyarallel/aio.py
+++ b/pyarallel/aio.py
@@ -18,8 +18,10 @@ from .core import (
     RateLimit,
     Retry,
     _Failure,
+    _iter_batches,
     _make_chunks,
     _merge_opts,
+    _total_if_known,
 )
 
 # ---------------------------------------------------------------------------
@@ -125,12 +127,47 @@ async def async_parallel_map[R](
     if concurrency < 1:
         raise ValueError(f"concurrency must be >= 1, got {concurrency}")
 
-    items_list = list(items)
-    n = len(items_list)
-    if n == 0:
-        return ParallelResult([])
+    if batch_size is None:
+        items_list = list(items)
+        n = len(items_list)
+        if n == 0:
+            return ParallelResult([])
 
-    results: list[Any] = [_PENDING] * n
+        results: list[Any] = [_PENDING] * n
+        semaphore = asyncio.Semaphore(concurrency)
+        limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
+        completed = 0
+
+        async def _run(i: int, item: Any) -> None:
+            nonlocal completed
+            async with semaphore:
+                if limiter:
+                    await limiter.wait()
+                try:
+                    if retry is not None:
+                        result = await _async_run_with_retry(
+                            fn, item, retry, task_timeout=task_timeout
+                        )
+                    elif task_timeout is not None:
+                        result = await asyncio.wait_for(fn(item), timeout=task_timeout)
+                    else:
+                        result = await fn(item)
+                    results[i] = result
+                except Exception as exc:
+                    results[i] = _Failure(exc)
+                completed += 1
+                if on_progress:
+                    on_progress(completed, n)
+
+        for chunk in _make_chunks(n, batch_size):
+            async with asyncio.TaskGroup() as tg:
+                for i in chunk:
+                    tg.create_task(_run(i, items_list[i]))
+
+        return ParallelResult(results)
+
+    total = _total_if_known(items)
+    results: list[Any] = []
     semaphore = asyncio.Semaphore(concurrency)
     limiter = _AsyncTokenBucket(rate_limit) if rate_limit else None
     completed = 0
@@ -154,12 +191,13 @@ async def async_parallel_map[R](
                 results[i] = _Failure(exc)
             completed += 1
             if on_progress:
-                on_progress(completed, n)
+                on_progress(completed, total if total is not None else len(results))
 
-    for chunk in _make_chunks(n, batch_size):
+    for batch in _iter_batches(items, batch_size):
+        results.extend([_PENDING] * len(batch))
         async with asyncio.TaskGroup() as tg:
-            for i in chunk:
-                tg.create_task(_run(i, items_list[i]))
+            for i, item in batch:
+                tg.create_task(_run(i, item))
 
     return ParallelResult(results)
 

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -580,7 +580,7 @@ def parallel_starmap[R](
     fn: Callable[..., R],
     items: Iterable[tuple[Any, ...]],
     *,
-    workers: int = 4,
+    workers: int | None = None,
     executor: ExecutorType = "thread",
     rate_limit: RateLimit | float | None = None,
     timeout: float | None = None,
@@ -633,7 +633,7 @@ def parallel_iter[R](
     fn: Callable[..., R],
     items: Iterable[Any],
     *,
-    workers: int = 4,
+    workers: int | None = None,
     executor: ExecutorType = "thread",
     rate_limit: RateLimit | float | None = None,
     batch_size: int | None = None,
@@ -657,7 +657,7 @@ def parallel_iter[R](
         rate_limit = RateLimit(rate_limit)
     if batch_size is not None and batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
-    if workers < 1:
+    if workers is not None and workers < 1:
         raise ValueError(f"workers must be >= 1, got {workers}")
     if executor not in ("thread", "process"):
         raise ValueError(f'executor must be "thread" or "process", got {executor!r}')

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -100,6 +100,27 @@ class Retry:
         return isinstance(exc, self.on)
 
 
+@dataclass(frozen=True, slots=True)
+class ItemResult[R]:
+    """Single streaming result item.
+
+    Exactly one of ``value`` or ``error`` is set.
+    """
+
+    index: int
+    value: R | None = None
+    error: Exception | None = None
+
+    def __post_init__(self) -> None:
+        if (self.value is None) == (self.error is None):
+            raise ValueError("Exactly one of value or error must be set")
+
+    @property
+    def ok(self) -> bool:
+        """True when this item succeeded."""
+        return self.error is None
+
+
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
@@ -610,21 +631,20 @@ def parallel_iter[R](
     rate_limit: RateLimit | float | None = None,
     batch_size: int | None = None,
     retry: Retry | None = None,
-) -> Iterator[tuple[int, R | Exception]]:
-    """Execute *fn* over *items* in parallel, yielding ``(index, result)``
-    in completion order.
+) -> Iterator[ItemResult[R]]:
+    """Execute *fn* over *items* in parallel, yielding ``ItemResult`` in
+    completion order.
 
     Unlike ``parallel_map``, results are not accumulated in memory — they
-    are yielded as they complete. For failed tasks, the value is the
-    exception instance.
+    are yielded as they complete.
 
     Example::
 
-        for index, value in parallel_iter(process, huge_list, batch_size=1000):
-            if isinstance(value, Exception):
-                log_error(index, value)
+        for item in parallel_iter(process, huge_list, batch_size=1000):
+            if item.ok:
+                db.save(item.value)
             else:
-                db.save(value)
+                log_error(item.index, item.error)
     """
     if isinstance(rate_limit, (int, float)):
         rate_limit = RateLimit(rate_limit)
@@ -688,9 +708,9 @@ def parallel_iter[R](
             for future in as_completed(futures):
                 idx = futures[future]
                 try:
-                    yield (idx, future.result())
+                    yield ItemResult(idx, value=future.result())
                 except Exception as exc:
-                    yield (idx, exc)
+                    yield ItemResult(idx, error=exc)
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
 
@@ -754,8 +774,8 @@ class _BoundParallel:
         self,
         items: Iterable[Any],
         **kwargs: Any,
-    ) -> Iterator[tuple[int, Any]]:
-        """Yield ``(index, result)`` in completion order — constant memory."""
+    ) -> Iterator[ItemResult[Any]]:
+        """Yield ``ItemResult`` in completion order — constant memory."""
         return parallel_iter(self._fn, items, **_merge_opts(self._defaults, **kwargs))
 
 
@@ -833,8 +853,8 @@ class _ParallelFunc:
         self,
         items: Iterable[Any],
         **kwargs: Any,
-    ) -> Iterator[tuple[int, Any]]:
-        """Yield ``(index, result)`` in completion order — constant memory."""
+    ) -> Iterator[ItemResult[Any]]:
+        """Yield ``ItemResult`` in completion order — constant memory."""
         return parallel_iter(
             self.__wrapped__, items, **_merge_opts(self._defaults, **kwargs)
         )

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -345,8 +345,13 @@ def parallel_map[R](
         rate_limit: ``RateLimit`` object, or a plain number (ops per second).
         timeout: Total wall-clock timeout in seconds for the whole operation.
         on_progress: ``callback(completed, total)`` fired after each task.
-        batch_size: Process items in chunks of this size to control memory.
-            Without batching, all items are submitted at once.
+            When ``items`` has no known length and ``batch_size`` is set,
+            ``total`` is the number of items seen so far rather than the
+            final input size.
+        batch_size: Process items in chunks of this size. With ``batch_size``
+            set, unsized iterables (for example generators) are consumed
+            lazily one batch at a time. Without batching, all items are
+            submitted at once.
         retry: ``Retry`` object for per-item retry with backoff.
 
     Returns:

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -135,6 +135,15 @@ class _Failure:
         self.exception = exception
 
 
+@dataclass(slots=True)
+class _CollectedMapPlan:
+    """Shared input plan for collected sync/async map execution."""
+
+    results: list[Any]
+    total: int | None
+    batches: Iterable[list[tuple[int, Any]]]
+
+
 class _TokenBucket:
     """Thread-safe token bucket rate limiter.
 
@@ -166,6 +175,18 @@ def _merge_opts(defaults: dict[str, Any], **overrides: Any) -> dict[str, Any]:
     return opts
 
 
+def _coerce_rate_limit(rate_limit: RateLimit | float | None) -> RateLimit | None:
+    """Normalize numeric rate limits into ``RateLimit`` objects."""
+    if isinstance(rate_limit, (int, float)):
+        return RateLimit(rate_limit)
+    return rate_limit
+
+
+def _progress_total(total: int | None, results: list[Any]) -> int:
+    """Return the best total to report in progress callbacks."""
+    return total if total is not None else len(results)
+
+
 def _make_chunks(n: int, batch_size: int | None) -> list[range]:
     """Split range(n) into chunks for batched processing."""
     if batch_size is not None and batch_size < n:
@@ -189,6 +210,32 @@ def _iter_batches(
         start = index
         index += len(batch)
         yield list(enumerate(batch, start))
+
+
+def _plan_collected_map(
+    items: Iterable[Any], batch_size: int | None
+) -> _CollectedMapPlan:
+    """Build the shared input plan for collected map-style execution."""
+    if batch_size is None:
+        items_list = list(items)
+        total = len(items_list)
+        batches = (
+            [*enumerate(items_list[start:stop], start)]
+            for start, stop in (
+                (chunk.start, chunk.stop) for chunk in _make_chunks(total, batch_size)
+            )
+        )
+        return _CollectedMapPlan(
+            results=[_PENDING] * total,
+            total=total,
+            batches=batches,
+        )
+
+    return _CollectedMapPlan(
+        results=[],
+        total=_total_if_known(items),
+        batches=_iter_batches(items, batch_size),
+    )
 
 
 def _total_if_known(items: Iterable[Any]) -> int | None:
@@ -378,8 +425,7 @@ def parallel_map[R](
     Returns:
         ``ParallelResult`` — acts like a list when all tasks succeed.
     """
-    if isinstance(rate_limit, (int, float)):
-        rate_limit = RateLimit(rate_limit)
+    rate_limit = _coerce_rate_limit(rate_limit)
     if batch_size is not None and batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
     if workers is not None and workers < 1:
@@ -427,94 +473,49 @@ def parallel_map[R](
     deadline = (time.monotonic() + timeout) if timeout is not None else None
     timed_out = False
 
-    if batch_size is None:
-        items_list = list(items)
-        n = len(items_list)
-        if n == 0:
-            return ParallelResult([])
-        results: list[Any] = [_PENDING] * n
+    plan = _plan_collected_map(items, batch_size)
+    if plan.total == 0:
+        return ParallelResult([])
+    results = plan.results
 
-        pool = pool_cls(max_workers=workers)
-        try:
-            for chunk in _make_chunks(n, batch_size):
-                chunk_timeout: float | None = None
-                if deadline is not None:
-                    chunk_timeout = max(0.0, deadline - time.monotonic())
-                    if chunk_timeout <= 0:
-                        for i in chunk:
-                            if results[i] is _PENDING:
-                                results[i] = _Failure(
+    pool = pool_cls(max_workers=workers)
+    try:
+        for batch in plan.batches:
+            chunk_timeout: float | None = None
+            if deadline is not None:
+                chunk_timeout = max(0.0, deadline - time.monotonic())
+                if chunk_timeout <= 0:
+                    for idx, _item in batch:
+                        if results[idx] is _PENDING:
+                            results[idx] = _Failure(
+                                TimeoutError(
+                                    f"Task {idx} did not complete within {timeout}s"
+                                )
+                            )
+                    if batch_size is not None:
+                        for item in items:
+                            idx = len(results)
+                            _ = item
+                            results.append(
+                                _Failure(
                                     TimeoutError(
-                                        f"Task {i} did not complete within {timeout}s"
+                                        f"Task {idx} did not complete within {timeout}s"
                                     )
                                 )
-                        timed_out = True
-                        continue
-
-                futures: dict[Future[R], int] = {}
-                for i in chunk:
-                    if bucket:
-                        bucket.wait()
-                    futures[pool.submit(task_fn, items_list[i])] = i
-
-                try:
-                    for future in as_completed(futures, timeout=chunk_timeout):
-                        idx = futures[future]
-                        try:
-                            results[idx] = future.result()
-                        except Exception as exc:
-                            results[idx] = _Failure(exc)
-                        completed += 1
-                        if on_progress:
-                            on_progress(completed, n)
-                except TimeoutError:
-                    timed_out = True
-                    for f, idx in futures.items():
-                        if not f.done():
-                            f.cancel()
+                            )
+                    else:
+                        for idx in range(len(results)):
                             if results[idx] is _PENDING:
                                 results[idx] = _Failure(
                                     TimeoutError(
                                         f"Task {idx} did not complete within {timeout}s"
                                     )
                                 )
-        finally:
-            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
-
-        return ParallelResult(results)
-
-    total = _total_if_known(items)
-    results: list[Any] = []
-
-    pool = pool_cls(max_workers=workers)
-    try:
-        for batch in _iter_batches(items, batch_size):
-            chunk_timeout: float | None = None
-            if deadline is not None:
-                chunk_timeout = max(0.0, deadline - time.monotonic())
-                if chunk_timeout <= 0:
-                    for idx, _item in batch:
-                        results.append(
-                            _Failure(
-                                TimeoutError(
-                                    f"Task {idx} did not complete within {timeout}s"
-                                )
-                            )
-                        )
-                    for item in items:
-                        idx = len(results)
-                        _ = item
-                        results.append(
-                            _Failure(
-                                TimeoutError(
-                                    f"Task {idx} did not complete within {timeout}s"
-                                )
-                            )
-                        )
                     timed_out = True
                     break
 
-            results.extend([_PENDING] * len(batch))
+            if batch_size is not None:
+                results.extend([_PENDING] * len(batch))
 
             futures: dict[Future[R], int] = {}
             for idx, item in batch:
@@ -531,10 +532,7 @@ def parallel_map[R](
                         results[idx] = _Failure(exc)
                     completed += 1
                     if on_progress:
-                        on_progress(
-                            completed,
-                            total if total is not None else len(results),
-                        )
+                        on_progress(completed, _progress_total(plan.total, results))
             except TimeoutError:
                 timed_out = True
                 for f, idx in futures.items():
@@ -546,16 +544,17 @@ def parallel_map[R](
                                     f"Task {idx} did not complete within {timeout}s"
                                 )
                             )
-                for item in items:
-                    idx = len(results)
-                    _ = item
-                    results.append(
-                        _Failure(
-                            TimeoutError(
-                                f"Task {idx} did not complete within {timeout}s"
+                if batch_size is not None:
+                    for item in items:
+                        idx = len(results)
+                        _ = item
+                        results.append(
+                            _Failure(
+                                TimeoutError(
+                                    f"Task {idx} did not complete within {timeout}s"
+                                )
                             )
                         )
-                    )
                 break
     finally:
         pool.shutdown(wait=not timed_out, cancel_futures=timed_out)

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -26,6 +26,7 @@ ExecutorType = Literal["thread", "process"]
 
 # Sentinel for "slot not yet filled" — distinct from a legitimate None return.
 _PENDING = object()
+_MISSING = object()
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ class Retry:
         return isinstance(exc, self.on)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(init=False, frozen=True, slots=True)
 class ItemResult[R]:
     """Single streaming result item.
 
@@ -108,12 +109,22 @@ class ItemResult[R]:
     """
 
     index: int
-    value: R | None = None
-    error: Exception | None = None
+    value: R | None
+    error: Exception | None
 
-    def __post_init__(self) -> None:
-        if (self.value is None) == (self.error is None):
+    def __init__(
+        self,
+        index: int,
+        value: R | None | object = _MISSING,
+        error: Exception | None | object = _MISSING,
+    ) -> None:
+        has_value = value is not _MISSING
+        has_error = error is not _MISSING
+        if has_value == has_error:
             raise ValueError("Exactly one of value or error must be set")
+        object.__setattr__(self, "index", index)
+        object.__setattr__(self, "value", value if has_value else None)
+        object.__setattr__(self, "error", error if has_error else None)
 
     @property
     def ok(self) -> bool:
@@ -142,6 +153,7 @@ class _CollectedMapPlan:
     results: list[Any]
     total: int | None
     batches: Iterable[list[tuple[int, Any]]]
+    remaining: Iterator[Any] | None = None
 
 
 class _TokenBucket:
@@ -201,7 +213,13 @@ def _iter_batches(
     items: Iterable[Any], batch_size: int
 ) -> Iterator[list[tuple[int, Any]]]:
     """Yield indexed item batches lazily from *items*."""
-    it = iter(items)
+    yield from _iter_batches_from_iterator(iter(items), batch_size)
+
+
+def _iter_batches_from_iterator(
+    it: Iterator[Any], batch_size: int
+) -> Iterator[list[tuple[int, Any]]]:
+    """Yield indexed item batches lazily from an existing iterator."""
     index = 0
     while True:
         batch = list(islice(it, batch_size))
@@ -234,8 +252,33 @@ def _plan_collected_map(
     return _CollectedMapPlan(
         results=[],
         total=_total_if_known(items),
-        batches=_iter_batches(items, batch_size),
+        batches=_iter_batches_from_iterator(source := iter(items), batch_size),
+        remaining=source,
     )
+
+
+def _timeout_failure(timeout: float, idx: int) -> _Failure:
+    """Create a consistent timeout failure wrapper."""
+    return _Failure(TimeoutError(f"Task {idx} did not complete within {timeout}s"))
+
+
+def _mark_timeout_indices(
+    results: list[Any], indices: Iterable[int], timeout: float
+) -> None:
+    """Fill any still-pending result slots at *indices* with timeout failures."""
+    for idx in indices:
+        if results[idx] is _PENDING:
+            results[idx] = _timeout_failure(timeout, idx)
+
+
+def _append_timeout_failures(
+    results: list[Any], remaining: Iterator[Any] | None, timeout: float
+) -> None:
+    """Drain remaining unseen input items and append timeout failures."""
+    if remaining is None:
+        return
+    for _item in remaining:
+        results.append(_timeout_failure(timeout, len(results)))
 
 
 def _total_if_known(items: Iterable[Any]) -> int | None:
@@ -481,41 +524,21 @@ def parallel_map[R](
     pool = pool_cls(max_workers=workers)
     try:
         for batch in plan.batches:
+            if batch_size is not None:
+                results.extend([_PENDING] * len(batch))
+
             chunk_timeout: float | None = None
             if deadline is not None:
                 chunk_timeout = max(0.0, deadline - time.monotonic())
                 if chunk_timeout <= 0:
-                    for idx, _item in batch:
-                        if results[idx] is _PENDING:
-                            results[idx] = _Failure(
-                                TimeoutError(
-                                    f"Task {idx} did not complete within {timeout}s"
-                                )
-                            )
-                    if batch_size is not None:
-                        for item in items:
-                            idx = len(results)
-                            _ = item
-                            results.append(
-                                _Failure(
-                                    TimeoutError(
-                                        f"Task {idx} did not complete within {timeout}s"
-                                    )
-                                )
-                            )
-                    else:
-                        for idx in range(len(results)):
-                            if results[idx] is _PENDING:
-                                results[idx] = _Failure(
-                                    TimeoutError(
-                                        f"Task {idx} did not complete within {timeout}s"
-                                    )
-                                )
+                    _mark_timeout_indices(
+                        results, (idx for idx, _item in batch), timeout
+                    )
+                    _append_timeout_failures(results, plan.remaining, timeout)
+                    if batch_size is None:
+                        _mark_timeout_indices(results, range(len(results)), timeout)
                     timed_out = True
                     break
-
-            if batch_size is not None:
-                results.extend([_PENDING] * len(batch))
 
             futures: dict[Future[R], int] = {}
             for idx, item in batch:
@@ -535,26 +558,11 @@ def parallel_map[R](
                         on_progress(completed, _progress_total(plan.total, results))
             except TimeoutError:
                 timed_out = True
-                for f, idx in futures.items():
+                for f, _idx in futures.items():
                     if not f.done():
                         f.cancel()
-                        if results[idx] is _PENDING:
-                            results[idx] = _Failure(
-                                TimeoutError(
-                                    f"Task {idx} did not complete within {timeout}s"
-                                )
-                            )
-                if batch_size is not None:
-                    for item in items:
-                        idx = len(results)
-                        _ = item
-                        results.append(
-                            _Failure(
-                                TimeoutError(
-                                    f"Task {idx} did not complete within {timeout}s"
-                                )
-                            )
-                        )
+                _mark_timeout_indices(results, futures.values(), timeout)
+                _append_timeout_failures(results, plan.remaining, timeout)
                 break
     finally:
         pool.shutdown(wait=not timed_out, cancel_futures=timed_out)

--- a/pyarallel/core.py
+++ b/pyarallel/core.py
@@ -19,6 +19,7 @@ from concurrent.futures import (
     as_completed,
 )
 from dataclasses import dataclass
+from itertools import islice
 from typing import Any, Literal
 
 ExecutorType = Literal["thread", "process"]
@@ -152,6 +153,29 @@ def _make_chunks(n: int, batch_size: int | None) -> list[range]:
             for start in range(0, n, batch_size)
         ]
     return [range(n)]
+
+
+def _iter_batches(
+    items: Iterable[Any], batch_size: int
+) -> Iterator[list[tuple[int, Any]]]:
+    """Yield indexed item batches lazily from *items*."""
+    it = iter(items)
+    index = 0
+    while True:
+        batch = list(islice(it, batch_size))
+        if not batch:
+            break
+        start = index
+        index += len(batch)
+        yield list(enumerate(batch, start))
+
+
+def _total_if_known(items: Iterable[Any]) -> int | None:
+    """Return len(items) when available without forcing materialization."""
+    try:
+        return len(items)  # type: ignore[arg-type]
+    except TypeError:
+        return None
 
 
 def _resolve_process_target(
@@ -345,11 +369,6 @@ def parallel_map[R](
             "For per-task timeouts, use async_parallel_map with task_timeout=."
         )
 
-    items_list = list(items)
-    n = len(items_list)
-    if n == 0:
-        return ParallelResult([])
-
     task_fn = fn
     if executor == "process":
         resolved = _resolve_process_target(fn)
@@ -378,33 +397,104 @@ def parallel_map[R](
 
     pool_cls = ThreadPoolExecutor if executor == "thread" else ProcessPoolExecutor
     bucket = _TokenBucket(rate_limit) if rate_limit else None
-    results: list[Any] = [_PENDING] * n
     completed = 0
     deadline = (time.monotonic() + timeout) if timeout is not None else None
     timed_out = False
 
+    if batch_size is None:
+        items_list = list(items)
+        n = len(items_list)
+        if n == 0:
+            return ParallelResult([])
+        results: list[Any] = [_PENDING] * n
+
+        pool = pool_cls(max_workers=workers)
+        try:
+            for chunk in _make_chunks(n, batch_size):
+                chunk_timeout: float | None = None
+                if deadline is not None:
+                    chunk_timeout = max(0.0, deadline - time.monotonic())
+                    if chunk_timeout <= 0:
+                        for i in chunk:
+                            if results[i] is _PENDING:
+                                results[i] = _Failure(
+                                    TimeoutError(
+                                        f"Task {i} did not complete within {timeout}s"
+                                    )
+                                )
+                        timed_out = True
+                        continue
+
+                futures: dict[Future[R], int] = {}
+                for i in chunk:
+                    if bucket:
+                        bucket.wait()
+                    futures[pool.submit(task_fn, items_list[i])] = i
+
+                try:
+                    for future in as_completed(futures, timeout=chunk_timeout):
+                        idx = futures[future]
+                        try:
+                            results[idx] = future.result()
+                        except Exception as exc:
+                            results[idx] = _Failure(exc)
+                        completed += 1
+                        if on_progress:
+                            on_progress(completed, n)
+                except TimeoutError:
+                    timed_out = True
+                    for f, idx in futures.items():
+                        if not f.done():
+                            f.cancel()
+                            if results[idx] is _PENDING:
+                                results[idx] = _Failure(
+                                    TimeoutError(
+                                        f"Task {idx} did not complete within {timeout}s"
+                                    )
+                                )
+        finally:
+            pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
+
+        return ParallelResult(results)
+
+    total = _total_if_known(items)
+    results: list[Any] = []
+
     pool = pool_cls(max_workers=workers)
     try:
-        for chunk in _make_chunks(n, batch_size):
+        for batch in _iter_batches(items, batch_size):
             chunk_timeout: float | None = None
             if deadline is not None:
                 chunk_timeout = max(0.0, deadline - time.monotonic())
                 if chunk_timeout <= 0:
-                    for i in chunk:
-                        if results[i] is _PENDING:
-                            results[i] = _Failure(
+                    for idx, _item in batch:
+                        results.append(
+                            _Failure(
                                 TimeoutError(
-                                    f"Task {i} did not complete within {timeout}s"
+                                    f"Task {idx} did not complete within {timeout}s"
                                 )
                             )
+                        )
+                    for item in items:
+                        idx = len(results)
+                        _ = item
+                        results.append(
+                            _Failure(
+                                TimeoutError(
+                                    f"Task {idx} did not complete within {timeout}s"
+                                )
+                            )
+                        )
                     timed_out = True
-                    continue
+                    break
+
+            results.extend([_PENDING] * len(batch))
 
             futures: dict[Future[R], int] = {}
-            for i in chunk:
+            for idx, item in batch:
                 if bucket:
                     bucket.wait()
-                futures[pool.submit(task_fn, items_list[i])] = i
+                futures[pool.submit(task_fn, item)] = idx
 
             try:
                 for future in as_completed(futures, timeout=chunk_timeout):
@@ -415,7 +505,10 @@ def parallel_map[R](
                         results[idx] = _Failure(exc)
                     completed += 1
                     if on_progress:
-                        on_progress(completed, n)
+                        on_progress(
+                            completed,
+                            total if total is not None else len(results),
+                        )
             except TimeoutError:
                 timed_out = True
                 for f, idx in futures.items():
@@ -427,6 +520,17 @@ def parallel_map[R](
                                     f"Task {idx} did not complete within {timeout}s"
                                 )
                             )
+                for item in items:
+                    idx = len(results)
+                    _ = item
+                    results.append(
+                        _Failure(
+                            TimeoutError(
+                                f"Task {idx} did not complete within {timeout}s"
+                            )
+                        )
+                    )
+                break
     finally:
         pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -193,18 +193,3 @@ class TestAsyncDecorator:
         assert await f.fetch("a") == "data-a"
         results = await f.fetch.map(["a", "b", "c"])
         assert list(results) == ["data-a", "data-b", "data-c"]
-
-
-class TestAsyncWorkersAlias:
-    async def test_workers_warns_and_works(self):
-        async def double(x):
-            return x * 2
-
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = await async_parallel_map(double, [1, 2, 3], workers=2)
-            assert len(w) == 1
-            assert "did you mean concurrency" in str(w[0].message)
-        assert list(result) == [2, 4, 6]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -149,6 +149,17 @@ class TestBatchWithOtherFeatures:
         elapsed = time.monotonic() - start
         assert elapsed >= 0.4  # 6 items at 10/sec
 
+    def test_timeout_with_list_does_not_double_count_remaining_items(self):
+        def slow(x):
+            time.sleep(0.2)
+            return x
+
+        result = parallel_map(
+            slow, list(range(10)), workers=2, batch_size=3, timeout=0.1
+        )
+        assert len(result) == 10
+        assert len(result.failures()) == 10
+
 
 class TestAsyncBatch:
     async def test_async_batch_produces_correct_results(self):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -62,6 +62,42 @@ class TestBatchMemoryControl:
         assert sorted(seen) == list(range(17))
         assert list(result) == list(range(17))
 
+    def test_batch_size_consumes_generator_lazily(self):
+        produced = []
+        started = threading.Event()
+        release = threading.Event()
+        current = 0
+        lock = threading.Lock()
+        holder = {}
+
+        def items():
+            for i in range(6):
+                produced.append(i)
+                yield i
+
+        def track(x):
+            nonlocal current
+            with lock:
+                current += 1
+                if current == 2:
+                    started.set()
+            release.wait(timeout=2)
+            with lock:
+                current -= 1
+            return x
+
+        def run():
+            holder["result"] = parallel_map(track, items(), workers=2, batch_size=2)
+
+        t = threading.Thread(target=run)
+        t.start()
+        assert started.wait(timeout=2)
+        assert produced == [0, 1]
+        release.set()
+        t.join(timeout=2)
+        assert not t.is_alive()
+        assert list(holder["result"]) == list(range(6))
+
 
 class TestBatchErrorHandling:
     def test_error_in_one_batch_still_processes_others(self):
@@ -147,3 +183,45 @@ class TestAsyncBatch:
 
         await async_parallel_map(track, range(20), concurrency=3, batch_size=5)
         assert max_concurrent <= 5  # batch_size caps in-flight tasks
+
+    async def test_async_batch_consumes_generator_lazily(self):
+        import asyncio
+
+        from pyarallel import async_parallel_map
+
+        produced = []
+        started = threading.Event()
+        release = threading.Event()
+        current = 0
+        lock = threading.Lock()
+        holder = {}
+
+        def items():
+            for i in range(6):
+                produced.append(i)
+                yield i
+
+        async def track(x):
+            nonlocal current
+            with lock:
+                current += 1
+                if current == 2:
+                    started.set()
+            await asyncio.to_thread(release.wait, 2)
+            with lock:
+                current -= 1
+            return x
+
+        def run():
+            holder["result"] = asyncio.run(
+                async_parallel_map(track, items(), concurrency=2, batch_size=2)
+            )
+
+        t = threading.Thread(target=run)
+        t.start()
+        assert started.wait(timeout=2)
+        assert produced == [0, 1]
+        release.set()
+        t.join(timeout=2)
+        assert not t.is_alive()
+        assert list(holder["result"]) == list(range(6))

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -79,8 +79,12 @@ class TestDecoratorOverrides:
 
     def test_process_executor_stream(self):
         results = list(_process_double.stream([1, 2, 3]))
-        results.sort()
-        assert results == [(0, 2), (1, 4), (2, 6)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 2),
+            (1, 4),
+            (2, 6),
+        ]
 
 
 class TestMethodSupport:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,8 +1,8 @@
-"""Tests for ParallelResult."""
+"""Tests for ParallelResult and ItemResult."""
 
 import pytest
 
-from pyarallel import ParallelResult
+from pyarallel import ItemResult, ParallelResult
 from pyarallel.core import _Failure
 
 
@@ -170,3 +170,27 @@ class TestValidation:
         for per in ("second", "minute", "hour"):
             r = RateLimit(10, per)
             assert r.per_second > 0
+
+
+class TestItemResult:
+    def test_success(self):
+        item = ItemResult[int](index=2, value=42)
+        assert item.ok is True
+        assert item.index == 2
+        assert item.value == 42
+        assert item.error is None
+
+    def test_failure(self):
+        err = ValueError("bad")
+        item = ItemResult[int](index=3, error=err)
+        assert item.ok is False
+        assert item.index == 3
+        assert item.value is None
+        assert item.error is err
+
+    def test_requires_exactly_one_of_value_or_error(self):
+        with pytest.raises(ValueError):
+            ItemResult[int](index=0)
+
+        with pytest.raises(ValueError):
+            ItemResult[int](index=0, value=1, error=ValueError("bad"))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -44,6 +44,14 @@ class TestParallelIterBasic:
             (3, 3),
         ]
 
+    def test_none_values_are_valid_results(self):
+        from pyarallel import parallel_iter
+
+        results = list(parallel_iter(lambda x: None, [1, 2, 3], workers=2))
+        results.sort(key=lambda item: item.index)
+        assert all(item.ok for item in results)
+        assert [item.value for item in results] == [None, None, None]
+
 
 class TestParallelIterStreaming:
     def test_constant_memory_with_batching(self):
@@ -220,3 +228,70 @@ class TestAsyncParallelIter:
             (1, 4),
             (2, 6),
         ]
+
+    async def test_none_values_are_valid_results(self):
+        from pyarallel import async_parallel_iter
+
+        results = []
+        async for item in async_parallel_iter(
+            _async_none, [1, 2, 3], concurrency=2
+        ):
+            results.append(item)
+
+        results.sort(key=lambda item: item.index)
+        assert all(item.ok for item in results)
+        assert [item.value for item in results] == [None, None, None]
+
+    async def test_batch_size_consumes_generator_lazily(self):
+        import asyncio
+        import threading
+
+        from pyarallel import async_parallel_iter
+
+        produced = []
+        started = threading.Event()
+        release = threading.Event()
+        current = 0
+        lock = threading.Lock()
+        holder = {}
+
+        def items():
+            for i in range(6):
+                produced.append(i)
+                yield i
+
+        async def track(x):
+            nonlocal current
+            with lock:
+                current += 1
+                if current == 2:
+                    started.set()
+            await asyncio.to_thread(release.wait, 2)
+            with lock:
+                current -= 1
+            return x
+
+        def run():
+            async def collect():
+                collected = []
+                async for item in async_parallel_iter(
+                    track, items(), concurrency=2, batch_size=2
+                ):
+                    collected.append(item)
+                holder["result"] = collected
+
+            asyncio.run(collect())
+
+        t = threading.Thread(target=run)
+        t.start()
+        assert started.wait(timeout=2)
+        assert produced == [0, 1]
+        release.set()
+        t.join(timeout=2)
+        assert not t.is_alive()
+        holder["result"].sort(key=lambda item: item.index)
+        assert [item.value for item in holder["result"]] == list(range(6))
+
+
+async def _async_none(_x):
+    return None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -7,13 +7,17 @@ from pyarallel.core import Retry
 
 
 class TestParallelIterBasic:
-    def test_yields_index_and_value(self):
+    def test_yields_item_result(self):
         from pyarallel import parallel_iter
 
         results = list(parallel_iter(lambda x: x * 2, [1, 2, 3], workers=2))
-        # Results come in completion order, so sort by index
-        results.sort()
-        assert results == [(0, 2), (1, 4), (2, 6)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 2),
+            (1, 4),
+            (2, 6),
+        ]
+        assert all(item.ok for item in results)
 
     def test_empty_input(self):
         from pyarallel import parallel_iter
@@ -24,13 +28,21 @@ class TestParallelIterBasic:
         from pyarallel import parallel_iter
 
         results = list(parallel_iter(lambda x: x * 10, [5], workers=1))
-        assert results == [(0, 50)]
+        assert len(results) == 1
+        assert results[0].index == 0
+        assert results[0].value == 50
 
     def test_accepts_any_iterable(self):
         from pyarallel import parallel_iter
 
         results = list(parallel_iter(lambda x: x, range(4), workers=2))
-        assert sorted(results) == [(0, 0), (1, 1), (2, 2), (3, 3)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+        ]
 
 
 class TestParallelIterStreaming:
@@ -39,7 +51,7 @@ class TestParallelIterStreaming:
         from pyarallel import parallel_iter
 
         yielded_count = 0
-        for _index, _value in parallel_iter(
+        for _item in parallel_iter(
             lambda x: x * 2,
             range(20),
             workers=2,
@@ -59,13 +71,13 @@ class TestParallelIterStreaming:
             return x
 
         results = list(parallel_iter(speed_varies, [0, 1, 2], workers=3))
-        indices = [i for i, _ in results]
+        indices = [item.index for item in results]
         # Index 0 should come last (it sleeps)
         assert indices[-1] == 0
 
 
 class TestParallelIterErrors:
-    def test_errors_yielded_as_exceptions(self):
+    def test_errors_yielded_as_item_results(self):
         from pyarallel import parallel_iter
 
         def maybe_fail(x):
@@ -74,12 +86,12 @@ class TestParallelIterErrors:
             return x
 
         results = list(parallel_iter(maybe_fail, [1, 2, 3], workers=2))
-        successes = [(i, v) for i, v in results if not isinstance(v, Exception)]
-        failures = [(i, v) for i, v in results if isinstance(v, Exception)]
+        successes = [item for item in results if item.ok]
+        failures = [item for item in results if not item.ok]
 
         assert len(successes) == 2
         assert len(failures) == 1
-        assert isinstance(failures[0][1], ValueError)
+        assert isinstance(failures[0].error, ValueError)
 
     def test_errors_with_retry(self):
         from pyarallel import parallel_iter
@@ -100,8 +112,8 @@ class TestParallelIterErrors:
                 retry=Retry(attempts=3, backoff=0, jitter=False),
             )
         )
-        results.sort()
-        assert results == [(0, 10), (1, 20)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [(0, 10), (1, 20)]
 
 
 class TestParallelIterWithOptions:
@@ -130,8 +142,10 @@ class TestParallelIterWithOptions:
                 batch_size=5,
             )
         )
-        results.sort()
-        assert results == [(i, i * 2) for i in range(15)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (i, i * 2) for i in range(15)
+        ]
 
 
 class TestDecoratorStream:
@@ -143,8 +157,12 @@ class TestDecoratorStream:
             return x * 2
 
         results = list(double.stream([1, 2, 3]))
-        results.sort()
-        assert results == [(0, 2), (1, 4), (2, 6)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 2),
+            (1, 4),
+            (2, 6),
+        ]
 
     def test_instance_method_stream(self):
         from pyarallel import parallel
@@ -159,8 +177,12 @@ class TestDecoratorStream:
 
         m = Mul(3)
         results = list(m.go.stream([1, 2, 3]))
-        results.sort()
-        assert results == [(0, 3), (1, 6), (2, 9)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 3),
+            (1, 6),
+            (2, 9),
+        ]
 
 
 class TestAsyncParallelIter:
@@ -171,11 +193,15 @@ class TestAsyncParallelIter:
             return x * 2
 
         results = []
-        async for index, value in async_parallel_iter(double, [1, 2, 3], concurrency=2):
-            results.append((index, value))
+        async for item in async_parallel_iter(double, [1, 2, 3], concurrency=2):
+            results.append(item)
 
-        results.sort()
-        assert results == [(0, 2), (1, 4), (2, 6)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 2),
+            (1, 4),
+            (2, 6),
+        ]
 
     async def test_async_decorator_stream(self):
         from pyarallel import async_parallel
@@ -185,8 +211,12 @@ class TestAsyncParallelIter:
             return x * 2
 
         results = []
-        async for index, value in double.stream([1, 2, 3]):
-            results.append((index, value))
+        async for item in double.stream([1, 2, 3]):
+            results.append(item)
 
-        results.sort()
-        assert results == [(0, 2), (1, 4), (2, 6)]
+        results.sort(key=lambda item: item.index)
+        assert [(item.index, item.value) for item in results] == [
+            (0, 2),
+            (1, 4),
+            (2, 6),
+        ]


### PR DESCRIPTION
## Summary

- **Lazy batch input**: `parallel_map` and `async_parallel_map` now consume generators lazily when `batch_size` is set, instead of eagerly materializing all items. `async_parallel_iter` also fixed.
- **Unified streaming errors**: Streaming APIs (`parallel_iter`, `async_parallel_iter`) now yield `ItemResult` objects instead of raw `(index, value|exception)` tuples. Consistent `.ok`, `.value`, `.error`, `.index` interface.
- **Remove async `workers` alias**: Async API uses `concurrency` only — no more confusing dual naming.
- **Consistent `workers` default**: All sync APIs now default to `workers=None` (stdlib decides), not a mix of `None` and `4`.
- **Shared sync/async planning**: Extracted `_plan_collected_map` and helpers shared between sync and async map paths to prevent behavior drift.
- **Modernize tooling**: Replace `black`+`isort` with `ruff` for formatting and linting. Migrate `TypeVar` to PEP 695 type parameters.
- **Fix `ItemResult` with `None` values**: Functions returning `None` no longer produce false errors.
- **Fix timeout drain**: Lazy-batch timeout path now correctly drains the shared iterator, not the original iterable.
- **Docs and examples**: Updated all API docs, examples, CLAUDE.md, and CONTRIBUTING.md to match current API.

## Test plan

- [x] 152 tests pass (`make test`)
- [x] `ruff check` and `ruff format --check` clean
- [x] Manual verification: `ItemResult` with `None`, falsy values (`False`, `0`, `""`, `[]`)
- [x] Manual verification: lazy generator consumption in sync and async paths
- [x] Manual verification: timeout + lazy batch doesn't double-count or index OOB
- [x] Manual verification: `workers=None` default works for `parallel_starmap` and `parallel_iter`